### PR TITLE
Fix "Input 'version' has been deprecated…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        version: ${{ matrix.ruby }}       
+        ruby-version: ${{ matrix.ruby }}       
     - name: Build and test with Rake
       run: |
         gem install bundler


### PR DESCRIPTION
with message: The version property will not be supported after October 1, 2019. Use ruby-version instead" deprecation message

See https://github.com/github/secure_headers/actions/runs/39770083

