### PR TITLE
Add rubocop-performance gem and config to fix deprecation message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
 inherit_gem:
   rubocop-github:
     - config/default.yml
+require: rubocop-performance

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ group :test do
   gem "rack"
   gem "rspec"
   gem "rubocop", "< 0.68"
-  gem "rubocop-performance"
   gem "rubocop-github"
+  gem "rubocop-performance"
   gem "term-ansicolor"
   gem "tins"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem "rack"
   gem "rspec"
   gem "rubocop", "< 0.68"
+  gem "rubocop-performance"
   gem "rubocop-github"
   gem "term-ansicolor"
   gem "tins"


### PR DESCRIPTION
```
Post-install message from rubocop:
Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.

Put this in your Gemfile.

  gem 'rubocop-performance'

And then execute:

  $ bundle install

Put this into your .rubocop.yml.

  require: rubocop-performance
```