### PR TITLE
Raise on override defined config

### DIFF
--- a/docs/named_overrides_and_appends.md
+++ b/docs/named_overrides_and_appends.md
@@ -1,6 +1,6 @@
 ## Named Appends
 
-Named Appends are blocks of code that can be reused and composed during requests. e.g. If a certain partial is rendered conditionally, and the csp needs to be adjusted for that partial, you can create a named append for that situation. The value returned by the block will be passed into `append_content_security_policy_directives`. The current request object is passed as an argument to the block for even more flexibility.
+Named Appends are blocks of code that can be reused and composed during requests. e.g. If a certain partial is rendered conditionally, and the csp needs to be adjusted for that partial, you can create a named append for that situation. The value returned by the block will be passed into `append_content_security_policy_directives`. The current request object is passed as an argument to the block for even more flexibility. Reusing a configuration name is not allowed and will throw an exception.
 
 ```ruby
 def show
@@ -90,6 +90,8 @@ class MyController < ApplicationController
   end
 end
 ```
+
+Reusing a configuration name is not allowed and will throw an exception.
 
 By default, a no-op configuration is provided. No headers will be set when this default override is used.
 

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -60,6 +60,7 @@ module SecureHeaders
       def named_append(name, &block)
         @appends ||= {}
         raise "Provide a configuration block" unless block_given?
+        raise AlreadyConfiguredError, "Configuration already exists" if @appends.key?(name)
         @appends[name] = block
       end
 

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -43,6 +43,7 @@ module SecureHeaders
       def override(name, &block)
         @overrides ||= {}
         raise "Provide a configuration block" unless block_given?
+        raise AlreadyConfiguredError, "Configuration already exists" if @overrides.key?(name)
         @overrides[name] = block
       end
 

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -43,7 +43,9 @@ module SecureHeaders
       def override(name, &block)
         @overrides ||= {}
         raise "Provide a configuration block" unless block_given?
-        raise AlreadyConfiguredError, "Configuration already exists" if @overrides.key?(name)
+        if named_append_or_override_exists?(name)
+          raise AlreadyConfiguredError, "Configuration already exists"
+        end
         @overrides[name] = block
       end
 
@@ -60,7 +62,9 @@ module SecureHeaders
       def named_append(name, &block)
         @appends ||= {}
         raise "Provide a configuration block" unless block_given?
-        raise AlreadyConfiguredError, "Configuration already exists" if @appends.key?(name)
+        if named_append_or_override_exists?(name)
+          raise AlreadyConfiguredError, "Configuration already exists"
+        end
         @appends[name] = block
       end
 
@@ -69,6 +73,11 @@ module SecureHeaders
       end
 
       private
+
+      def named_append_or_override_exists?(name)
+        (defined?(@appends) && @appends.key?(name)) ||
+          (defined?(@overrides) && @overrides.key?(name))
+      end
 
       # Public: perform a basic deep dup. The shallow copy provided by dup/clone
       # can lead to modifying parent objects.

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -47,6 +47,19 @@ module SecureHeaders
         .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
     end
 
+    it "raises on configuring an existing append" do
+      set_override = Proc.new {
+        Configuration.named_append(:test_override) do |config|
+          config.x_frame_options = "DENY"
+        end
+      }
+
+      set_override.call
+
+      expect { set_override.call }
+        .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+    end
+
     it "deprecates the secure_cookies configuration" do
       expect {
         Configuration.default do |config|

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -34,6 +34,19 @@ module SecureHeaders
       expect(Configuration.overrides(:test_override)).to_not be_nil
     end
 
+    it "raises on configuring an existing override" do
+      set_override = Proc.new {
+        Configuration.override(:test_override) do |config|
+          config.x_frame_options = "DENY"
+        end
+      }
+
+      set_override.call
+
+      expect { set_override.call }
+        .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+    end
+
     it "deprecates the secure_cookies configuration" do
       expect {
         Configuration.default do |config|

--- a/spec/lib/secure_headers/configuration_spec.rb
+++ b/spec/lib/secure_headers/configuration_spec.rb
@@ -34,30 +34,58 @@ module SecureHeaders
       expect(Configuration.overrides(:test_override)).to_not be_nil
     end
 
-    it "raises on configuring an existing override" do
-      set_override = Proc.new {
-        Configuration.override(:test_override) do |config|
-          config.x_frame_options = "DENY"
-        end
-      }
+    describe "#override" do
+      it "raises on configuring an existing override" do
+        set_override = Proc.new {
+          Configuration.override(:test_override) do |config|
+            config.x_frame_options = "DENY"
+          end
+        }
 
-      set_override.call
+        set_override.call
 
-      expect { set_override.call }
-        .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
-    end
+        expect { set_override.call }
+          .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+      end
 
-    it "raises on configuring an existing append" do
-      set_override = Proc.new {
+      it "raises when a named append with the given name exists" do
         Configuration.named_append(:test_override) do |config|
           config.x_frame_options = "DENY"
         end
-      }
 
-      set_override.call
+        expect do
+          Configuration.override(:test_override) do |config|
+            config.x_frame_options = "SAMEORIGIN"
+          end
+        end.to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+      end
+    end
 
-      expect { set_override.call }
-        .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+    describe "#named_append" do
+      it "raises on configuring an existing append" do
+        set_override = Proc.new {
+          Configuration.named_append(:test_override) do |config|
+            config.x_frame_options = "DENY"
+          end
+        }
+
+        set_override.call
+
+        expect { set_override.call }
+          .to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+      end
+
+      it "raises when an override with the given name exists" do
+        Configuration.override(:test_override) do |config|
+          config.x_frame_options = "DENY"
+        end
+
+        expect do
+          Configuration.named_append(:test_override) do |config|
+            config.x_frame_options = "SAMEORIGIN"
+          end
+        end.to raise_error(Configuration::AlreadyConfiguredError, "Configuration already exists")
+      end
     end
 
     it "deprecates the secure_cookies configuration" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,6 +49,10 @@ module SecureHeaders
       def clear_overrides
         remove_instance_variable(:@overrides) if defined?(@overrides)
       end
+
+      def clear_appends
+        remove_instance_variable(:@appends) if defined?(@appends)
+      end
     end
   end
 end
@@ -56,4 +60,5 @@ end
 def reset_config
   SecureHeaders::Configuration.clear_default_config
   SecureHeaders::Configuration.clear_overrides
+  SecureHeaders::Configuration.clear_appends
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,10 +45,15 @@ module SecureHeaders
       def clear_default_config
         remove_instance_variable(:@default_config) if defined?(@default_config)
       end
+
+      def clear_overrides
+        remove_instance_variable(:@overrides) if defined?(@overrides)
+      end
     end
   end
 end
 
 def reset_config
   SecureHeaders::Configuration.clear_default_config
+  SecureHeaders::Configuration.clear_overrides
 end


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [x] Documentation updated

This PR changes the behavior of the `override` and `named_append` methods to raise an exception when it is called more than once with the same configuration name. This is to avoid unexpected behavior in case a configuration is used in some way in between two configuration declarations.

Fixes #435