### PR TITLE
replace references to 'master' with 'main' to reflect new branch strategy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build + Test
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:
@@ -10,14 +10,15 @@ jobs:
         ruby: [ '2.4', '2.5', '2.6' ]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby }}       
+        ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3 --without guard
         bundle exec rspec spec
-        bundle exec rubocop 
+        bundle exec rubocop
+

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,20 @@
+# This workflow ensures the "master" branch is always up-to-date with the
+# "main" branch (our default one)
+name: sync_main_branch
+on:
+  push:
+    branches: [ main ]
+jobs:
+  catch_up:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+        with:
+         fetch-depth: 0
+      - name: Merge development into master, then push it
+        run: |
+          git pull
+          git checkout master
+          git merge development
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,7 +372,7 @@ Adds `upgrade-insecure-requests` support for requests from Firefox and Chrome (a
 
 ## 3.0.0
 
-secure_headers 3.0.0 is a near-complete, not-entirely-backward-compatible rewrite. Please see the [upgrade guide](https://github.com/twitter/secureheaders/blob/master/docs/upgrading-to-3-0.md) for an in-depth explanation of the changes and the suggested upgrade path.
+secure_headers 3.0.0 is a near-complete, not-entirely-backward-compatible rewrite. Please see the [upgrade guide](https://github.com/twitter/secureheaders/blob/main/docs/upgrading-to-3-0.md) for an in-depth explanation of the changes and the suggested upgrade path.
 
 ## 2.5.1 - 2016-02-16 18:11:11 UTC - Remove noisy deprecation warning
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Secure Headers ![Build + Test](https://github.com/github/secure_headers/workflows/Build%20+%20Test/badge.svg?branch=master)  [![Code Climate](https://codeclimate.com/github/twitter/secureheaders.svg)](https://codeclimate.com/github/twitter/secureheaders) [![Coverage Status](https://coveralls.io/repos/twitter/secureheaders/badge.svg)](https://coveralls.io/r/twitter/secureheaders)
+# Secure Headers ![Build + Test](https://github.com/github/secure_headers/workflows/Build%20+%20Test/badge.svg?branch=main)  [![Code Climate](https://codeclimate.com/github/twitter/secureheaders.svg)](https://codeclimate.com/github/twitter/secureheaders) [![Coverage Status](https://coveralls.io/repos/twitter/secureheaders/badge.svg)](https://coveralls.io/r/twitter/secureheaders)
 
-**master represents 6.x line**. See the [upgrading to 4.x doc](docs/upgrading-to-4-0.md), [upgrading to 5.x doc](docs/upgrading-to-5-0.md), or [upgrading to 6.x doc](docs/upgrading-to-6-0.md) for instructions on how to upgrade. Bug fixes should go in the 5.x branch for now.
+**main branch represents 6.x line**. See the [upgrading to 4.x doc](docs/upgrading-to-4-0.md), [upgrading to 5.x doc](docs/upgrading-to-5-0.md), or [upgrading to 6.x doc](docs/upgrading-to-6-0.md) for instructions on how to upgrade. Bug fixes should go in the 5.x branch for now.
 
 The gem will automatically apply several headers that are related to security.  This includes:
 - Content Security Policy (CSP) - Helps detect/prevent XSS, mixed-content, and other classes of attack.  [CSP 2 Specification](http://www.w3.org/TR/CSP2/)


### PR DESCRIPTION
One of the directives still uses a `master-only` value so I can't remove all (yet). The default branch for the repo has already been changed. 

This (should) keep `main` and `master` in sync just in case. I'll remove it soon after.
