### PR TITLE
Add test to exercise override opting out without default_src

### DIFF
--- a/spec/lib/secure_headers_spec.rb
+++ b/spec/lib/secure_headers_spec.rb
@@ -117,6 +117,17 @@ module SecureHeaders
         expect(hash[XFrameOptions::HEADER_NAME]).to eq(XFrameOptions::SAMEORIGIN)
       end
 
+      it "allows you to override opting out without default_src" do
+        Configuration.default do |config|
+          config.csp = OPT_OUT
+        end
+
+        SecureHeaders.override_content_security_policy_directives(request, { frame_ancestors: %w('none') }, :enforced)
+
+        hash = SecureHeaders.header_hash_for(request)
+        expect(hash[ContentSecurityPolicyConfig::HEADER_NAME]).to eq("default-src https:; script-src 'self'")
+      end
+
       it "produces a hash of headers with default config" do
         Configuration.default
         hash = SecureHeaders.header_hash_for(request)


### PR DESCRIPTION
On secure_headers 5.x it was possible to override the CSP directives when optin out without having to define a default_src.

Now on 6.x it is required to set the default_src when overriding other directives.

It is not clear in the CHANGELOG/upgrade guide if this change is by design or if it is just a side effect of other changes.

I could not find anything in the spec that says that default_src is required or not, so I decided to open a PR with a test to get feedback on that.

If this is undesirable behavior I'm willing to change this PR to fix the problem.

Let me know what are the next steps.

Thanks.

