### PR TITLE
Deadlink in readme file in this repo to https://github.com/sourceclear/headlines which does not exist - Status code [404:NotFound]

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ If you've made a contribution and see your name missing from the list, make a PR
 * Rack [rack-secure_headers](https://github.com/frodsan/rack-secure_headers)
 * Node.js (express) [helmet](https://github.com/helmetjs/helmet) and [hood](https://github.com/seanmonstar/hood)
 * Node.js (hapi) [blankie](https://github.com/nlf/blankie)
-* J2EE Servlet >= 3.0 [headlines](https://github.com/sourceclear/headlines)
 * ASP.NET - [NWebsec](https://github.com/NWebsec/NWebsec/wiki)
 * Python - [django-csp](https://github.com/mozilla/django-csp) + [commonware](https://github.com/jsocol/commonware/); [django-security](https://github.com/sdelements/django-security)
 * Go - [secureheader](https://github.com/kr/secureheader)


### PR DESCRIPTION

In this repo's readme there is a link to: https://github.com/sourceclear/headlines
This is in section for "Similar libraries".
However that is a deadlink and gives Status code [404:NotFound].

Looking at https://github.com/sourceclear there does not appear to be any similar named repos belonging to them.
So I assume this is not a simple typo and that this repo has been removed.

Perhaps the simplest thing to do here is to just remove this "Similar libraries" reference all together?
So that is what I have done in this PR.

However please feel free to suggest an alternate approach.

## extra

I recently created a tool that makes use of the GitHub api to find repos that match certain parameters. Then this tool checks the repo's readme files for dead links: 
https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

It can be used to re-check this repo via this url: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fgithub%2fsecure_headers

I'd love to hear some feedback on this project so please feel free to to share some thoughts, or even start a discussion on the repo's main GitHub page.




## All PRs:

* [N/A] Has tests
* [X] Documentation updated

## Adding a new header
N/A

## Adding a new CSP directive
N/A

