### PR TITLE
Add disable_minification option to CSP config to bypass any post-processing of config data

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -104,7 +104,11 @@ module SecureHeaders
     def build_source_list_directive(directive)
       source_list = @config.directive_value(directive)
       if source_list != OPT_OUT && source_list && source_list.any?
-        minified_source_list = minify_source_list(directive, source_list).join(" ")
+        minified_source_list = if @config[:disable_minification]
+          source_list
+        else
+          minify_source_list(directive, source_list)
+        end.join(" ")
 
         if minified_source_list =~ /(\n|;)/
           Kernel.warn("#{directive} contains a #{$1} in #{minified_source_list.inspect} which will raise an error in future versions. It has been replaced with a blank space.")

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -43,6 +43,7 @@ module SecureHeaders
       @worker_src = nil
       @upgrade_insecure_requests = nil
       @disable_nonce_backwards_compatibility = nil
+      @disable_minification = nil
 
       from_hash(hash)
     end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -154,7 +154,8 @@ module SecureHeaders
     META_CONFIGS = [
       :report_only,
       :preserve_schemes,
-      :disable_nonce_backwards_compatibility
+      :disable_nonce_backwards_compatibility,
+      :disable_minification,
     ].freeze
 
     NONCES = [

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -56,6 +56,15 @@ module SecureHeaders
         expect(csp.value).to eq("default-src *.example.org")
       end
 
+      it "preserves source expressions based on overlapping wildcards when configured" do
+        config = {
+          default_src: %w(a.example.org b.example.org *.example.org https://*.example.org),
+          disable_minification: true,
+        }
+        csp = ContentSecurityPolicy.new(config)
+        expect(csp.value).to eq("default-src a.example.org b.example.org *.example.org https://*.example.org")
+      end
+
       it "removes http/s schemes from hosts" do
         csp = ContentSecurityPolicy.new(default_src: %w(https://example.org))
         expect(csp.value).to eq("default-src example.org")
@@ -104,6 +113,11 @@ module SecureHeaders
       it "deduplicates any source expressions" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org example.org))
         expect(csp.value).to eq("default-src example.org")
+      end
+
+      it "preserves any source expressions when configured" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org example.org), disable_minification: true)
+        expect(csp.value).to eq("default-src example.org example.org example.org")
       end
 
       it "creates maximally strict sandbox policy when passed no sandbox token values" do


### PR DESCRIPTION
This PR disables any post-processing of CSP configs when generating a policy. This was prompted by a review of the performance of a typical request. While there are likely plenty of code optimizations that can be made, turning off functionality also makes things go vroom. 

The minification has been buggy and has led to confusion but for those who have a policy that doesn't demand these features, it's wasteful. 

I'll follow up with actual data on how much time is spent in these methods and the impact this could make, but this was the result from a (mostly) empty endpoint. 2.5% of a request cycle to generate a string.

```
        32   (0.7%)          32   (0.7%)     SecureHeaders::ContentSecurityPolicy#dedup_source_list
        27   (0.6%)          27   (0.6%)     SecureHeaders::ContentSecurityPolicy#strip_source_schemes
        29   (0.6%)          26   (0.6%)     SecureHeaders::DynamicConfig#directive_value
        26   (0.6%)          26   (0.6%)     SecureHeaders::DynamicConfig#write_attribute
```

## All PRs:

* [ ] Has tests
* [ ] Documentation updated

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?

