### PR TITLE
Add ability to cache default header set

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -142,11 +142,10 @@ module SecureHeaders
       prevent_dup = true
       config = config_for(request, prevent_dup)
 
-      headers = if config.modified
+      headers = config.default_headers unless config.modified
+      headers ||= begin
         config.validate_config!
         config.generate_headers
-      else
-        config.default_headers || config.generate_headers
       end
 
       if request.scheme != HTTPS

--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -141,8 +141,13 @@ module SecureHeaders
     def header_hash_for(request)
       prevent_dup = true
       config = config_for(request, prevent_dup)
-      config.validate_config!
-      headers = config.generate_headers
+
+      headers = if config.modified
+        config.validate_config!
+        config.generate_headers
+      else
+        config.default_headers || config.generate_headers
+      end
 
       if request.scheme != HTTPS
         headers.delete(StrictTransportSecurity::HEADER_NAME)
@@ -240,6 +245,7 @@ module SecureHeaders
     #
     # Returns the config.
     def override_secure_headers_request_config(request, config)
+      config.modified = true
       request.env[SECURE_HEADERS_CONFIG] = config
     end
   end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -167,6 +167,8 @@ module SecureHeaders
       @x_permitted_cross_domain_policies = nil
       @x_xss_protection = nil
       @expect_certificate_transparency = nil
+      @modified = false
+      @default_headers = nil
 
       self.referrer_policy = OPT_OUT
       self.csp = ContentSecurityPolicyConfig.new(ContentSecurityPolicyConfig::DEFAULT)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -27,9 +27,11 @@ module SecureHeaders
           end
         end
 
-        new_config = new(&block).freeze
+        new_config = new(&block)
         new_config.validate_config!
-        @default_config = new_config
+        new_config.default_headers = new_config.generate_headers
+
+        @default_config = new_config.freeze
       end
       alias_method :configure, :default
 
@@ -140,6 +142,8 @@ module SecureHeaders
     attr_writer(*(CONFIG_ATTRIBUTES_TO_HEADER_CLASSES.reject { |key| [:csp, :csp_report_only].include?(key) }.keys))
 
     attr_reader(*(CONFIG_ATTRIBUTES_TO_HEADER_CLASSES.keys))
+
+    attr_accessor :modified, :default_headers
 
     @script_hashes = nil
     @style_hashes = nil


### PR DESCRIPTION
While I was playing around with https://github.com/github/secure_headers/pull/452, I re-stumbled on a really easy way to save computations for the base case. 

This creates a foundation for e.g. caching the default header set for `overrides` but I didn't want to go there just yet. Obviously, the cached policy is super fast 😄 

```
[last: 5s][secure_headers (cache-default-policies %)]$ ruby test.rb
{"Strict-Transport-Security"=>"max-age=631138519", "X-Frame-Options"=>"sameorigin", "X-Content-Type-Options"=>"nosniff", "X-XSS-Protection"=>"1; mode=block", "X-Download-Options"=>"noopen", "X-Permitted-Cross-Domain-Policies"=>"none", "Content-Security-Policy"=>"default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'"}
Warming up --------------------------------------
             /status   246.533k i/100ms
Calculating -------------------------------------
             /status      2.489M (± 1.8%) i/s -     12.573M in   5.052716s
stackprof-status.dump
==================================
  Mode: wall(1000)
  Samples: 5059 (0.00% miss rate)
  GC: 0 (0.00%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      2422  (47.9%)        2422  (47.9%)     SecureHeaders::Configuration.default_config
      1177  (23.3%)        1177  (23.3%)     Rack::Request::Env#get_header
      5029  (99.4%)         734  (14.5%)     #<Module:0x00007fcb941fedb8>.header_hash_for
      2787  (55.1%)         365   (7.2%)     #<Module:0x00007fcb941fedb8>.config_for
      1508  (29.8%)         331   (6.5%)     Rack::Request::Helpers#scheme
      5059 (100.0%)          30   (0.6%)     block (2 levels) in <main>
      5059 (100.0%)           0   (0.0%)     <main>
      5059 (100.0%)           0   (0.0%)     <main>
      5059 (100.0%)           0   (0.0%)     block in <main>
```