### PR TITLE
Don't reference the request object until after the application stack has run

### DIFF
--- a/lib/secure_headers/middleware.rb
+++ b/lib/secure_headers/middleware.rb
@@ -7,9 +7,8 @@ module SecureHeaders
 
     # merges the hash of headers into the current header set.
     def call(env)
-      req = Rack::Request.new(env)
       status, headers, response = @app.call(env)
-
+      req = Rack::Request.new(env)
       config = SecureHeaders.config_for(req)
       flag_cookies!(headers, override_secure(env, config.cookies)) unless config.cookies == OPT_OUT
       headers.merge!(SecureHeaders.header_hash_for(req))


### PR DESCRIPTION
I need to run a profiler to verify this matters, but we don't actually need to instantiate the `req` until after `app.call` returns.

A result of https://github.com/github/secure_headers/pull/452