### PR TITLE
[micro-optimization] use regexp.match instead of =~

### DIFF
--- a/lib/secure_headers/headers/cookie.rb
+++ b/lib/secure_headers/headers/cookie.rb
@@ -6,7 +6,7 @@ require "secure_headers/utils/cookies_config"
 module SecureHeaders
   class CookiesConfigError < StandardError; end
   class Cookie
-
+    COOKIE_PATTERN = /[;,]\s?/
     class << self
       def validate_config!(config)
         CookiesConfig.new(config).validate!
@@ -136,7 +136,7 @@ module SecureHeaders
     def parse(cookie)
       return unless cookie
 
-      cookie.split(/[;,]\s?/).each do |pairs|
+      cookie.split(COOKIE_PATTERN).each do |pairs|
         name, values = pairs.split("=", 2)
         name = CGI.unescape(name)
 

--- a/lib/secure_headers/headers/expect_certificate_transparency.rb
+++ b/lib/secure_headers/headers/expect_certificate_transparency.rb
@@ -8,6 +8,7 @@ module SecureHeaders
     INVALID_ENFORCE_VALUE_ERROR = "enforce must be a boolean".freeze
     REQUIRED_MAX_AGE_ERROR      = "max-age is a required directive.".freeze
     INVALID_MAX_AGE_ERROR       = "max-age must be a number.".freeze
+    MAX_AGE_PATTERN = /\A\d+\z/
 
     class << self
       # Public: Generate a Expect-CT header.
@@ -31,7 +32,7 @@ module SecureHeaders
 
         if !config[:max_age]
           raise ExpectCertificateTransparencyConfigError.new(REQUIRED_MAX_AGE_ERROR)
-        elsif config[:max_age].to_s !~ /\A\d+\z/
+        elsif !MAX_AGE_PATTERN.match?(config[:max_age].to_s)
           raise ExpectCertificateTransparencyConfigError.new(INVALID_MAX_AGE_ERROR)
         end
       end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -142,6 +142,7 @@ module SecureHeaders
 
     STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
+    MEDIA_TYPE_EXPRESSION = /\A.+\/.+\z/
 
     WILDCARD_SOURCES = [
       UNSAFE_EVAL,
@@ -339,7 +340,7 @@ module SecureHeaders
         ensure_array_of_strings!(directive, media_type_expression)
         valid = media_type_expression.compact.all? do |v|
           # All media types are of the form: <type from RFC 2045> "/" <subtype from RFC 2045>.
-          v =~ /\A.+\/.+\z/
+          MEDIA_TYPE_EXPRESSION.match?(v)
         end
         if !valid
           raise ContentSecurityPolicyConfigError.new("#{directive} must be an array of valid media types (ex. application/pdf)")

--- a/lib/secure_headers/headers/strict_transport_security.rb
+++ b/lib/secure_headers/headers/strict_transport_security.rb
@@ -22,7 +22,7 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config == OPT_OUT
         raise TypeError.new("Must be a string. Found #{config.class}: #{config} #{config.class}") unless config.is_a?(String)
-        raise STSConfigError.new(MESSAGE) unless config =~ VALID_STS_HEADER
+        raise STSConfigError.new(MESSAGE) unless VALID_STS_HEADER.match?(config)
       end
     end
   end

--- a/lib/secure_headers/headers/x_frame_options.rb
+++ b/lib/secure_headers/headers/x_frame_options.rb
@@ -23,7 +23,7 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config == OPT_OUT
         raise TypeError.new("Must be a string. Found #{config.class}: #{config}") unless config.is_a?(String)
-        unless config =~ VALID_XFO_HEADER
+        unless VALID_XFO_HEADER.match?(config)
           raise XFOConfigError.new("Value must be SAMEORIGIN|DENY|ALLOW-FROM:|ALLOWALL")
         end
       end

--- a/lib/secure_headers/headers/x_xss_protection.rb
+++ b/lib/secure_headers/headers/x_xss_protection.rb
@@ -19,7 +19,7 @@ module SecureHeaders
       def validate_config!(config)
         return if config.nil? || config == OPT_OUT
         raise TypeError.new("Must be a string. Found #{config.class}: #{config}") unless config.is_a?(String)
-        raise XXssProtectionConfigError.new("Invalid format (see VALID_X_XSS_HEADER)") unless config.to_s =~ VALID_X_XSS_HEADER
+        raise XXssProtectionConfigError.new("Invalid format (see VALID_X_XSS_HEADER)") unless VALID_X_XSS_HEADER.match?(config)
       end
     end
   end


### PR DESCRIPTION
Before:

```
Warming up --------------------------------------
             /status     1.410k i/100ms
Calculating -------------------------------------
             /status     14.438k (± 2.0%) i/s -     73.320k in   5.080602s
stackprof-status.dump
==================================
  Mode: wall(1000)
  Samples: 5154 (0.00% miss rate)
  GC: 448 (8.69%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1022  (19.8%)         590  (11.4%)     SecureHeaders::DynamicConfig#directive_value
      2205  (42.8%)         472   (9.2%)     SecureHeaders::ContentSecurityPolicy#build_source_list_directive
       435   (8.4%)         435   (8.4%)     SecureHeaders::ContentSecurityPolicyConfig.attrs
       418   (8.1%)         418   (8.1%)     SecureHeaders::ContentSecurityPolicy#strip_source_schemes
       411   (8.0%)         411   (8.0%)     SecureHeaders::ContentSecurityPolicy#dedup_source_list
       374   (7.3%)         374   (7.3%)     (sweeping)
       297   (5.8%)         297   (5.8%)     SecureHeaders::ContentSecurityPolicy#symbol_to_hyphen_case
       157   (3.0%)         157   (3.0%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_sources!
       119   (2.3%)         119   (2.3%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_array_of_strings!
       118   (2.3%)         118   (2.3%)     SecureHeaders::ContentSecurityPolicy#directives
        87   (1.7%)          87   (1.7%)     SecureHeaders::CookiesConfig#is_hash?
       362   (7.0%)          86   (1.7%)     SecureHeaders::PolicyManagement::ClassMethods#validate_source_expression!
      3066  (59.5%)          82   (1.6%)     SecureHeaders::Configuration#generate_headers
        81   (1.6%)          81   (1.6%)     SecureHeaders::ContentSecurityPolicy#reject_all_values_if_none
        74   (1.4%)          74   (1.4%)     (marking)
      1038  (20.1%)          72   (1.4%)     SecureHeaders::ContentSecurityPolicy#minify_source_list
      2506  (48.6%)          65   (1.3%)     SecureHeaders::ContentSecurityPolicy#build_value
        62   (1.2%)          62   (1.2%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_directive!
      1084  (21.0%)          57   (1.1%)     SecureHeaders::PolicyManagement::ClassMethods#validate_config!
        54   (1.0%)          54   (1.0%)     SecureHeaders::DynamicConfig#==
        48   (0.9%)          48   (0.9%)     SecureHeaders::StrictTransportSecurity.make_header
        56   (1.1%)          47   (0.9%)     SecureHeaders::ContentSecurityPolicy#populate_nonces
      2672  (51.8%)          46   (0.9%)     SecureHeaders::PolicyManagement::ClassMethods#make_header
        46   (0.9%)          46   (0.9%)     SecureHeaders::ExpectCertificateTransparency.make_header
        45   (0.9%)          45   (0.9%)     SecureHeaders::ContentSecurityPolicy#initialize
        44   (0.9%)          44   (0.9%)     SecureHeaders::StrictTransportSecurity.validate_config!
        43   (0.8%)          43   (0.8%)     SecureHeaders::XPermittedCrossDomainPolicies.make_header
        42   (0.8%)          42   (0.8%)     SecureHeaders::DynamicConfig#opt_out?
        40   (0.8%)          40   (0.8%)     SecureHeaders::ExpectCertificateTransparency.validate_config!
        39   (0.8%)          39   (0.8%)     SecureHeaders::Configuration.default_config
```

After

```
Warming up --------------------------------------
             /status     1.520k i/100ms
Calculating -------------------------------------
             /status     15.426k (± 1.9%) i/s -     77.520k in   5.027188s
stackprof-status.dump
==================================
  Mode: wall(1000)
  Samples: 5060 (0.00% miss rate)
  GC: 435 (8.60%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1037  (20.5%)         582  (11.5%)     SecureHeaders::DynamicConfig#directive_value
      2002  (39.6%)         555  (11.0%)     SecureHeaders::ContentSecurityPolicy#build_source_list_directive
       457   (9.0%)         457   (9.0%)     SecureHeaders::ContentSecurityPolicyConfig.attrs
       453   (9.0%)         453   (9.0%)     SecureHeaders::ContentSecurityPolicy#strip_source_schemes
       370   (7.3%)         370   (7.3%)     (sweeping)
       243   (4.8%)         243   (4.8%)     SecureHeaders::ContentSecurityPolicy#dedup_source_list
       177   (3.5%)         177   (3.5%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_sources!
       140   (2.8%)         140   (2.8%)     SecureHeaders::ContentSecurityPolicy#directives
       134   (2.6%)         134   (2.6%)     SecureHeaders::ContentSecurityPolicy#symbol_to_hyphen_case
       124   (2.5%)         124   (2.5%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_array_of_strings!
       101   (2.0%)         101   (2.0%)     SecureHeaders::CookiesConfig#is_hash?
        83   (1.6%)          83   (1.6%)     SecureHeaders::ContentSecurityPolicy#reject_all_values_if_none
      2913  (57.6%)          82   (1.6%)     SecureHeaders::Configuration#generate_headers
        76   (1.5%)          76   (1.5%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_directive!
      2334  (46.1%)          76   (1.5%)     SecureHeaders::ContentSecurityPolicy#build_value
        65   (1.3%)          65   (1.3%)     (marking)
      1101  (21.8%)          63   (1.2%)     SecureHeaders::PolicyManagement::ClassMethods#validate_config!
       364   (7.2%)          63   (1.2%)     SecureHeaders::PolicyManagement::ClassMethods#validate_source_expression!
       894  (17.7%)          62   (1.2%)     SecureHeaders::ContentSecurityPolicy#minify_source_list
        48   (0.9%)          48   (0.9%)     SecureHeaders::StrictTransportSecurity.validate_config!
        48   (0.9%)          48   (0.9%)     SecureHeaders::DynamicConfig#opt_out?
        47   (0.9%)          47   (0.9%)     SecureHeaders::XPermittedCrossDomainPolicies.make_header
        47   (0.9%)          47   (0.9%)     SecureHeaders::XPermittedCrossDomainPolicies.validate_config!
        46   (0.9%)          46   (0.9%)     SecureHeaders::StrictTransportSecurity.make_header
        45   (0.9%)          45   (0.9%)     SecureHeaders::XXssProtection.make_header
        45   (0.9%)          45   (0.9%)     SecureHeaders::ReferrerPolicy.validate_config!
        45   (0.9%)          45   (0.9%)     SecureHeaders::ReferrerPolicy.make_header
        44   (0.9%)          44   (0.9%)     SecureHeaders::CookiesConfig#initialize
        43   (0.8%)          43   (0.8%)     SecureHeaders::ExpectCertificateTransparency.make_header
      2470  (48.8%)          42   (0.8%)     SecureHeaders::PolicyManagement::ClassMethods#make_header
```

## All PRs:

* [ ] Has tests
* [ ] Documentation updated

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?

