### PR TITLE
use un-rolled method for duplciating configs instead of serializing to and from hash

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -34,6 +34,10 @@ module SecureHeaders
       self.class.instance
     end
 
+    def self.from_self(instance)
+      instance
+    end
+
     def opt_out?
       true
     end

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -244,7 +244,7 @@ module SecureHeaders
       when OPT_OUT
         @csp = new_csp
       when ContentSecurityPolicyConfig
-        @csp = new_csp
+        @csp = new_csp.class.from_self(new_csp)
       when Hash
         @csp = ContentSecurityPolicyConfig.new(new_csp)
       else
@@ -263,7 +263,7 @@ module SecureHeaders
       when OPT_OUT
         @csp_report_only = new_csp
       when ContentSecurityPolicyReportOnlyConfig
-        @csp_report_only = new_csp.dup
+        @csp_report_only = new_csp.class.from_self(new_csp)
       when ContentSecurityPolicyConfig
         @csp_report_only = new_csp.make_report_only
       when Hash

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -193,7 +193,7 @@ module SecureHeaders
           raise ContentSecurityPolicyConfigError.new("csp_report_only config must have :report_only set to true")
         end
 
-        ContentSecurityPolicyConfig.attrs.each do |key|
+        ContentSecurityPolicyConfig::ATTRS.each do |key|
           value = config.directive_value(key)
           next unless value
 


### PR DESCRIPTION
To my surprise, this seems to have dubious performance benefits. The `dup`s were happening via `write_attribute`...