### PR TITLE
modify lists in place instead of returning new objects

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -104,76 +104,71 @@ module SecureHeaders
     def build_source_list_directive(directive)
       source_list = @config.directive_value(directive)
       if source_list != OPT_OUT && source_list && source_list.any?
-        minified_source_list = minify_source_list(directive, source_list).join(" ")
+        minify_source_list!(directive, source_list)
+        sources = source_list.join(" ")
 
-        if minified_source_list =~ /(\n|;)/
-          Kernel.warn("#{directive} contains a #{$1} in #{minified_source_list.inspect} which will raise an error in future versions. It has been replaced with a blank space.")
+        if sources =~ /(\n|;)/
+          Kernel.warn("#{directive} contains a #{$1} in #{sources.inspect} which will raise an error in future versions. It has been replaced with a blank space.")
+          sources.gsub!(/[\n;]/, " ")
         end
 
-        escaped_source_list = minified_source_list.gsub(/[\n;]/, " ")
-        [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
+        [symbol_to_hyphen_case(directive), sources].join(" ").strip
       end
     end
 
     # If a directive contains *, all other values are omitted.
     # If a directive contains 'none' but has other values, 'none' is ommitted.
     # Schemes are stripped (see http://www.w3.org/TR/CSP2/#match-source-expression)
-    def minify_source_list(directive, source_list)
-      source_list = source_list.compact
+    def minify_source_list!(directive, source_list)
+      source_list.compact!
       if source_list.include?(STAR)
-        keep_wildcard_sources(source_list)
+        keep_wildcard_sources!(source_list)
       else
-        source_list = populate_nonces(directive, source_list)
-        source_list = reject_all_values_if_none(source_list)
+        populate_nonces!(directive, source_list)
+        reject_all_values_if_none!(source_list)
 
         unless directive == REPORT_URI || @preserve_schemes
-          source_list = strip_source_schemes(source_list)
+          strip_source_schemes!(source_list)
         end
-        dedup_source_list(source_list)
+        dedup_source_list!(source_list)
       end
     end
 
     # Discard trailing entries (excluding unsafe-*) since * accomplishes the same.
-    def keep_wildcard_sources(source_list)
-      source_list.select { |value| WILDCARD_SOURCES.include?(value) }
+    def keep_wildcard_sources!(source_list)
+      source_list.reject! { |value| !WILDCARD_SOURCES.include?(value) }
     end
 
     # Discard any 'none' values if more directives are supplied since none may override values.
-    def reject_all_values_if_none(source_list)
+    def reject_all_values_if_none!(source_list)
       if source_list.length > 1
-        source_list.reject { |value| value == NONE }
-      else
-        source_list
+        source_list.reject! { |value| value == NONE }
       end
     end
 
     # Removes duplicates and sources that already match an existing wild card.
     #
     # e.g. *.github.com asdf.github.com becomes *.github.com
-    def dedup_source_list(sources)
-      sources = sources.uniq
-      wild_sources = sources.select { |source| source =~ STAR_REGEXP }
+    def dedup_source_list!(sources)
+      sources.uniq!
+      wild_sources = sources.reject { |source| source !~ STAR_REGEXP }
 
       if wild_sources.any?
-        sources.reject do |source|
+        sources.reject! do |source|
           !wild_sources.include?(source) &&
             wild_sources.any? { |pattern| File.fnmatch(pattern, source) }
         end
-      else
-        sources
       end
     end
 
     # Private: append a nonce to the script/style directories if script_nonce
     # or style_nonce are provided.
-    def populate_nonces(directive, source_list)
+    def populate_nonces!(directive, source_list)
       case directive
       when SCRIPT_SRC
-        append_nonce(source_list, @script_nonce)
+        append_nonce!(source_list, @script_nonce)
       when STYLE_SRC
-        append_nonce(source_list, @style_nonce)
-      else
-        source_list
+        append_nonce!(source_list, @style_nonce)
       end
     end
 
@@ -182,13 +177,11 @@ module SecureHeaders
     #
     # While CSP is backward compatible in that a policy with a nonce will ignore
     # unsafe-inline, this is more concise.
-    def append_nonce(source_list, nonce)
+    def append_nonce!(source_list, nonce)
       if nonce
         source_list.push("'nonce-#{nonce}'")
         source_list.push(UNSAFE_INLINE) unless @config[:disable_nonce_backwards_compatibility]
       end
-
-      source_list
     end
 
     # Private: return the list of directives,
@@ -202,8 +195,8 @@ module SecureHeaders
     end
 
     # Private: Remove scheme from source expressions.
-    def strip_source_schemes(source_list)
-      source_list.map { |source_expression| source_expression.sub(HTTP_SCHEME_REGEX, "") }
+    def strip_source_schemes!(source_list)
+      source_list.map! { |source_expression| source_expression.sub(HTTP_SCHEME_REGEX, "") }
     end
 
     def symbol_to_hyphen_case(sym)


### PR DESCRIPTION
Before:

```
Warming up --------------------------------------
             /status     1.410k i/100ms
Calculating -------------------------------------
             /status     14.438k (± 2.0%) i/s -     73.320k in   5.080602s
stackprof-status.dump
==================================
  Mode: wall(1000)
  Samples: 5154 (0.00% miss rate)
  GC: 448 (8.69%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1022  (19.8%)         590  (11.4%)     SecureHeaders::DynamicConfig#directive_value
      2205  (42.8%)         472   (9.2%)     SecureHeaders::ContentSecurityPolicy#build_source_list_directive
       435   (8.4%)         435   (8.4%)     SecureHeaders::ContentSecurityPolicyConfig.attrs
       418   (8.1%)         418   (8.1%)     SecureHeaders::ContentSecurityPolicy#strip_source_schemes
       411   (8.0%)         411   (8.0%)     SecureHeaders::ContentSecurityPolicy#dedup_source_list
       374   (7.3%)         374   (7.3%)     (sweeping)
       297   (5.8%)         297   (5.8%)     SecureHeaders::ContentSecurityPolicy#symbol_to_hyphen_case
       157   (3.0%)         157   (3.0%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_sources!
       119   (2.3%)         119   (2.3%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_array_of_strings!
       118   (2.3%)         118   (2.3%)     SecureHeaders::ContentSecurityPolicy#directives
        87   (1.7%)          87   (1.7%)     SecureHeaders::CookiesConfig#is_hash?
       362   (7.0%)          86   (1.7%)     SecureHeaders::PolicyManagement::ClassMethods#validate_source_expression!
      3066  (59.5%)          82   (1.6%)     SecureHeaders::Configuration#generate_headers
        81   (1.6%)          81   (1.6%)     SecureHeaders::ContentSecurityPolicy#reject_all_values_if_none
        74   (1.4%)          74   (1.4%)     (marking)
      1038  (20.1%)          72   (1.4%)     SecureHeaders::ContentSecurityPolicy#minify_source_list
      2506  (48.6%)          65   (1.3%)     SecureHeaders::ContentSecurityPolicy#build_value
        62   (1.2%)          62   (1.2%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_directive!
      1084  (21.0%)          57   (1.1%)     SecureHeaders::PolicyManagement::ClassMethods#validate_config!
        54   (1.0%)          54   (1.0%)     SecureHeaders::DynamicConfig#==
        48   (0.9%)          48   (0.9%)     SecureHeaders::StrictTransportSecurity.make_header
        56   (1.1%)          47   (0.9%)     SecureHeaders::ContentSecurityPolicy#populate_nonces
      2672  (51.8%)          46   (0.9%)     SecureHeaders::PolicyManagement::ClassMethods#make_header
        46   (0.9%)          46   (0.9%)     SecureHeaders::ExpectCertificateTransparency.make_header
        45   (0.9%)          45   (0.9%)     SecureHeaders::ContentSecurityPolicy#initialize
        44   (0.9%)          44   (0.9%)     SecureHeaders::StrictTransportSecurity.validate_config!
        43   (0.8%)          43   (0.8%)     SecureHeaders::XPermittedCrossDomainPolicies.make_header
        42   (0.8%)          42   (0.8%)     SecureHeaders::DynamicConfig#opt_out?
        40   (0.8%)          40   (0.8%)     SecureHeaders::ExpectCertificateTransparency.validate_config!
        39   (0.8%)          39   (0.8%)     SecureHeaders::Configuration.default_config
```

After:

```
rc https:; style-src 'self' https: 'unsafe-inline'"}
Warming up --------------------------------------
             /status     1.464k i/100ms
Calculating -------------------------------------
             /status     14.897k (± 2.4%) i/s -     74.664k in   5.015040s
stackprof-status.dump
==================================
  Mode: wall(1000)
  Samples: 5063 (0.00% miss rate)
  GC: 429 (8.47%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1054  (20.8%)         597  (11.8%)     SecureHeaders::DynamicConfig#directive_value
      2170  (42.9%)         529  (10.4%)     SecureHeaders::ContentSecurityPolicy#build_source_list_directive
       459   (9.1%)         459   (9.1%)     SecureHeaders::ContentSecurityPolicyConfig.attrs
       442   (8.7%)         442   (8.7%)     SecureHeaders::ContentSecurityPolicy#strip_source_schemes!
       439   (8.7%)         439   (8.7%)     SecureHeaders::ContentSecurityPolicy#dedup_source_list!
       334   (6.6%)         334   (6.6%)     (sweeping)
       162   (3.2%)         162   (3.2%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_sources!
       138   (2.7%)         138   (2.7%)     SecureHeaders::ContentSecurityPolicy#directives
       129   (2.5%)         129   (2.5%)     SecureHeaders::ContentSecurityPolicy#symbol_to_hyphen_case
       105   (2.1%)         105   (2.1%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_array_of_strings!
        95   (1.9%)          95   (1.9%)     (marking)
        81   (1.6%)          81   (1.6%)     SecureHeaders::CookiesConfig#is_hash?
        80   (1.6%)          80   (1.6%)     SecureHeaders::PolicyManagement::ClassMethods#ensure_valid_directive!
        78   (1.5%)          78   (1.5%)     SecureHeaders::ContentSecurityPolicy#reject_all_values_if_none!
      1087  (21.5%)          63   (1.2%)     SecureHeaders::ContentSecurityPolicy#minify_source_list!
      1060  (20.9%)          61   (1.2%)     SecureHeaders::PolicyManagement::ClassMethods#validate_config!
      2995  (59.2%)          58   (1.1%)     SecureHeaders::Configuration#generate_headers
      2636  (52.1%)          57   (1.1%)     SecureHeaders::PolicyManagement::ClassMethods#make_header
        65   (1.3%)          57   (1.1%)     SecureHeaders::ContentSecurityPolicy#populate_nonces!
      2494  (49.3%)          56   (1.1%)     SecureHeaders::ContentSecurityPolicy#build_value
        56   (1.1%)          56   (1.1%)     SecureHeaders::ReferrerPolicy.validate_config!
       321   (6.3%)          54   (1.1%)     SecureHeaders::PolicyManagement::ClassMethods#validate_source_expression!
        51   (1.0%)          51   (1.0%)     SecureHeaders::NoOpHeaderConfig#opt_out?
        48   (0.9%)          48   (0.9%)     SecureHeaders::ExpectCertificateTransparency.make_header
        47   (0.9%)          47   (0.9%)     SecureHeaders::StrictTransportSecurity.make_header
        43   (0.8%)          43   (0.8%)     SecureHeaders::XPermittedCrossDomainPolicies.make_header
        40   (0.8%)          40   (0.8%)     SecureHeaders::CookiesConfig#initialize
        39   (0.8%)          39   (0.8%)     SecureHeaders::DynamicConfig#==
        39   (0.8%)          39   (0.8%)     SecureHeaders::CookiesConfig#validate_samesite_boolean_config!
        36   (0.7%)          36   (0.7%)     SecureHeaders::DynamicConfig#opt_out?
```