### PR TITLE
Add missing CSP version 3 directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ SecureHeaders::Configuration.default do |config|
     sandbox: true, # true and [] will set a maximally restrictive setting
     plugin_types: %w(application/x-shockwave-flash),
     script_src: %w('self'),
+    script_src_elem: %w('self'),
+    script_src_attr: %w('self'),
     style_src: %w('unsafe-inline'),
+    style_src_elem: %w('unsafe-inline'),
+    style_src_attr: %w('unsafe-inline'),
     worker_src: %w('self'),
     upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
     report_uri: %w(https://report-uri.io/example-csp)

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -38,8 +38,12 @@ module SecureHeaders
       @sandbox = nil
       @script_nonce = nil
       @script_src = nil
+      @script_src_elem = nil
+      @script_src_attr = nil
       @style_nonce = nil
       @style_src = nil
+      @style_src_elem = nil
+      @style_src_attr = nil
       @worker_src = nil
       @upgrade_insecure_requests = nil
       @disable_nonce_backwards_compatibility = nil

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -78,6 +78,10 @@ module SecureHeaders
     REQUIRE_SRI_FOR = :require_sri_for
     UPGRADE_INSECURE_REQUESTS = :upgrade_insecure_requests
     WORKER_SRC = :worker_src
+    SCRIPT_SRC_ELEM = :script_src_elem
+    SCRIPT_SRC_ATTR = :script_src_attr
+    STYLE_SRC_ELEM = :style_src_elem
+    STYLE_SRC_ATTR = :style_src_attr
 
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
@@ -87,7 +91,11 @@ module SecureHeaders
       PREFETCH_SRC,
       REQUIRE_SRI_FOR,
       WORKER_SRC,
-      UPGRADE_INSECURE_REQUESTS
+      UPGRADE_INSECURE_REQUESTS,
+      SCRIPT_SRC_ELEM,
+      SCRIPT_SRC_ATTR,
+      STYLE_SRC_ELEM,
+      STYLE_SRC_ATTR
     ].flatten.freeze
 
     ALL_DIRECTIVES = (DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0).uniq.sort
@@ -117,7 +125,11 @@ module SecureHeaders
       PREFETCH_SRC              => :source_list,
       SANDBOX                   => :sandbox_list,
       SCRIPT_SRC                => :source_list,
+      SCRIPT_SRC_ELEM           => :source_list,
+      SCRIPT_SRC_ATTR           => :source_list,
       STYLE_SRC                 => :source_list,
+      STYLE_SRC_ELEM            => :source_list,
+      STYLE_SRC_ATTR            => :source_list,
       WORKER_SRC                => :source_list,
       UPGRADE_INSECURE_REQUESTS => :boolean,
     }.freeze

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -160,6 +160,26 @@ module SecureHeaders
         csp = ContentSecurityPolicy.new({default_src: %w('self'), script_src: [ContentSecurityPolicy::STRICT_DYNAMIC], script_nonce: 123456, disable_nonce_backwards_compatibility: true })
         expect(csp.value).to eq("default-src 'self'; script-src 'strict-dynamic' 'nonce-123456'")
       end
+
+      it "supports script-src-elem directive" do
+        csp = ContentSecurityPolicy.new({script_src: %w('self'), script_src_elem: %w('self')})
+        expect(csp.value).to eq("script-src 'self'; script-src-elem 'self'")
+      end
+
+      it "supports script-src-attr directive" do
+        csp = ContentSecurityPolicy.new({script_src: %w('self'), script_src_attr: %w('self')})
+        expect(csp.value).to eq("script-src 'self'; script-src-attr 'self'")
+      end
+
+      it "supports style-src-elem directive" do
+        csp = ContentSecurityPolicy.new({style_src: %w('self'), style_src_elem: %w('self')})
+        expect(csp.value).to eq("style-src 'self'; style-src-elem 'self'")
+      end
+
+      it "supports style-src-attr directive" do
+        csp = ContentSecurityPolicy.new({style_src: %w('self'), style_src_attr: %w('self')})
+        expect(csp.value).to eq("style-src 'self'; style-src-attr 'self'")
+      end
     end
   end
 end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -49,6 +49,10 @@ module SecureHeaders
           style_src: %w('unsafe-inline'),
           upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
           worker_src: %w(worker.com),
+          script_src_elem: %w(example.com),
+          script_src_attr: %w(example.com),
+          style_src_elem: %w(example.com),
+          style_src_attr: %w(example.com),
 
           report_uri: %w(https://example.com/uri-directive),
         }


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [x] Documentation updated

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
  - Chrome, Edge, and Opera support them
  - Safari, Firefox, and IE **don't** support these directives yet
* What does it do?
  - More info about these at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src-attr
* What are the valid values for the directive?
  - These headers should allow any value that's valid for their parent directives `script_src` and `style_src`
* Where does the specification live?
  - https://w3c.github.io/webappsec-csp/#directive-script-src-attr
  - https://w3c.github.io/webappsec-csp/#directive-script-src-elem
  - https://w3c.github.io/webappsec-csp/#directive-style-src-attr
  - https://w3c.github.io/webappsec-csp/#directive-style-src-elem
