### PR TITLE
Add global config for nonce (and hash) application

### DIFF
--- a/lib/secure_headers.rb
+++ b/lib/secure_headers.rb
@@ -2,6 +2,7 @@
 require "secure_headers/hash_helper"
 require "secure_headers/headers/cookie"
 require "secure_headers/headers/content_security_policy"
+require "secure_headers/headers/content_security_policy_nonce_apply_to"
 require "secure_headers/headers/x_frame_options"
 require "secure_headers/headers/strict_transport_security"
 require "secure_headers/headers/x_xss_protection"
@@ -208,7 +209,7 @@ module SecureHeaders
 
     def config_and_target(request, target)
       config = config_for(request)
-      target = guess_target(config) unless target
+      target ||= config.csp_nonces_applied_to || guess_target(config)
       raise_on_unknown_target(target)
       [config, target]
     end
@@ -262,8 +263,8 @@ module SecureHeaders
     SecureHeaders.opt_out_of_header(request, header_key)
   end
 
-  def append_content_security_policy_directives(additions)
-    SecureHeaders.append_content_security_policy_directives(request, additions)
+  def append_content_security_policy_directives(additions, target)
+    SecureHeaders.append_content_security_policy_directives(request, additions, target)
   end
 
   def override_content_security_policy_directives(additions)

--- a/lib/secure_headers/configuration.rb
+++ b/lib/secure_headers/configuration.rb
@@ -126,6 +126,7 @@ module SecureHeaders
       expect_certificate_transparency: ExpectCertificateTransparency,
       csp: ContentSecurityPolicy,
       csp_report_only: ContentSecurityPolicy,
+      csp_nonces_applied_to: ContentSecurityPolicyNonceApplyTo,
       cookies: Cookie,
     }.freeze
 
@@ -135,7 +136,7 @@ module SecureHeaders
     VALIDATABLE_ATTRIBUTES = CONFIG_ATTRIBUTES
 
     # The list of attributes that must respond to a `make_header` method
-    HEADERABLE_ATTRIBUTES = (CONFIG_ATTRIBUTES - [:cookies]).freeze
+    HEADERABLE_ATTRIBUTES = (CONFIG_ATTRIBUTES - [:cookies, :csp_nonces_applied_to]).freeze
 
     attr_writer(*(CONFIG_ATTRIBUTES_TO_HEADER_CLASSES.reject { |key| [:csp, :csp_report_only].include?(key) }.keys))
 
@@ -163,6 +164,7 @@ module SecureHeaders
       @x_permitted_cross_domain_policies = nil
       @x_xss_protection = nil
       @expect_certificate_transparency = nil
+      @csp_nonces_applied_to = nil
 
       self.referrer_policy = OPT_OUT
       self.csp = ContentSecurityPolicyConfig.new(ContentSecurityPolicyConfig::DEFAULT)
@@ -179,6 +181,7 @@ module SecureHeaders
       copy.cookies = self.class.send(:deep_copy_if_hash, @cookies)
       copy.csp = @csp.dup if @csp
       copy.csp_report_only = @csp_report_only.dup if @csp_report_only
+      copy.csp_nonces_applied_to = @csp_nonces_applied_to
       copy.x_content_type_options = @x_content_type_options
       copy.hsts = @hsts
       copy.x_frame_options = @x_frame_options

--- a/lib/secure_headers/headers/content_security_policy_nonce_apply_to.rb
+++ b/lib/secure_headers/headers/content_security_policy_nonce_apply_to.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module SecureHeaders
+  class CSPNonceApplyToConfigError < StandardError; end
+
+  class ContentSecurityPolicyNonceApplyTo
+    ACCEPTABLE_VALUES = [:enforced, :report_only, :both]
+
+    class << self
+      def validate_config!(config)
+        return if config.nil?
+        raise TypeError.new("Must be one of :enforced, :report_only or both. Found #{config.class}: #{config} #{config.class}") unless ACCEPTABLE_VALUES.include?(config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* [X] Has tests
* [ ] Documentation updated

Fixes #470

Hi there!

Sorry for the long hiatus.
I'm opening this as is to get feedback on the proposal.
I've added a test case for my current scenario and it is currently passing.

However, I'm unsure what to do for some other scenarios.
I've put togueter a table with all possible combinations and marked the ones I'm unsure with "?"
This is assuming a call was made to `content_security_policy_script_nonce`


| CSP Config | Report Only Config | Apply Config | Result                     |
|------------|--------------------|--------------|----------------------------|
| PRESENT    | PRESENT            | nil          | nonce added to both        |
| PRESENT    | PRESENT            | :both        | nonce added to both        |
| PRESENT    | PRESENT            | :enforced    | nonce added to enforce     |
| PRESENT    | PRESENT            | :report_only | nonce added to report_only |
| PRESENT    | OPT_OUT            | nil          | nonce added to enforce     |
| PRESENT    | OPT_OUT            | :both        | ?                          |
| PRESENT    | OPT_OUT            | :enforced    | nonce added to enforce     |
| PRESENT    | OPT_OUT            | :report_only | ?                          |
| OPT_OUT    | PRESENT            | nil          | nonce added to report_only |
| OPT_OUT    | PRESENT            | :both        | ?                          |
| OPT_OUT    | PRESENT            | :enforced    | ?                          |
| OPT_OUT    | PRESENT            | :report_only | nonce added to report_only |
| OPT_OUT    | OPT_OUT            | nil          | ?                          |
| OPT_OUT    | OPT_OUT            | :both        | ?                          |
| OPT_OUT    | OPT_OUT            | :enforced    | ?                          |
| OPT_OUT    | OPT_OUT            | :report_only | ?                          |
