### PR TITLE
normalize domains with trailing slashes

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -125,6 +125,7 @@ module SecureHeaders
       else
         source_list = populate_nonces(directive, source_list)
         source_list = reject_all_values_if_none(source_list)
+        source_list = normalize_uri_paths(source_list)
 
         unless directive == REPORT_URI || @preserve_schemes
           source_list = strip_source_schemes(source_list)
@@ -146,6 +147,19 @@ module SecureHeaders
         source_list
       end
     end
+
+    def normalize_uri_paths(source_list)
+      source_list.map do |source|
+        # Normalize domains ending in a single / as without omitting the slash accomplisheg the same.
+        # https://www.w3.org/TR/CSP3/#match-paths § 6.6.2.10 Step 2
+        if source.chomp("/").include?("/")
+          source
+        else
+          source.chomp("/")
+        end
+      end
+    end
+
 
     # Removes duplicates and sources that already match an existing wild card.
     #

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -48,9 +48,17 @@ module SecureHeaders
         expect(csp.value).to eq("default-src * 'unsafe-inline' 'unsafe-eval' data: blob:")
       end
 
+      it "normalizes source expressions that end with a trailing /" do
+        config = {
+          default_src: %w(a.example.org/ b.example.com/ c.example.net/foo/ b.example.co/bar)
+        }
+        csp = ContentSecurityPolicy.new(config)
+        expect(csp.value).to eq("default-src a.example.org b.example.com c.example.net/foo/ b.example.co/bar")
+      end
+
       it "minifies source expressions based on overlapping wildcards" do
         config = {
-          default_src: %w(a.example.org b.example.org *.example.org https://*.example.org)
+          default_src: %w(a.example.org b.example.org *.example.org https://*.example.org c.example.org/)
         }
         csp = ContentSecurityPolicy.new(config)
         expect(csp.value).to eq("default-src *.example.org")


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [ ] Documentation updated - N/A

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?

---

This PR normalises CSP source expressions to exclude trailing slashes from the Domain _if_ there is no other information in the path.

CSP3 more explicitly calls this out in the [path match algorithm](https://www.w3.org/TR/CSP/#path-part-match):

> If path A consists of one character that is equal to the U+002F
> SOLIDUS character (/) and path B is empty, return "Matches".

Also a URL like `example.com/foo` will match a source expression of `example.com`, as well as `example.com/`, so having two source expressions listed like this is redundant.

