### PR TITLE
do not dedupe alternate schema source expresions

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -155,9 +155,10 @@ module SecureHeaders
       wild_sources = sources.select { |source| source =~ STAR_REGEXP }
 
       if wild_sources.any?
+        schemes = sources.map { |source| [source, URI(source).scheme] }.to_h
         sources.reject do |source|
           !wild_sources.include?(source) &&
-            wild_sources.any? { |pattern| URI(pattern).scheme == URI(source).scheme && File.fnmatch(pattern, source) }
+            wild_sources.any? { |pattern| schemes[pattern] == schemes[source] && File.fnmatch(pattern, source) }
         end
       else
         sources

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -157,7 +157,7 @@ module SecureHeaders
       if wild_sources.any?
         sources.reject do |source|
           !wild_sources.include?(source) &&
-            wild_sources.any? { |pattern| File.fnmatch(pattern, source) }
+            wild_sources.any? { |pattern| URI(pattern).scheme == URI(source).scheme && File.fnmatch(pattern, source) }
         end
       else
         sources

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -106,6 +106,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
+      it "does not deduplicate non-matching schema source expressions" do
+        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://*.example.org))
+        expect(csp.value).to eq("default-src *.example.org wss://*.example.org")
+      end
+
       it "creates maximally strict sandbox policy when passed no sandbox token values" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: [])
         expect(csp.value).to eq("default-src example.org; sandbox")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -107,8 +107,8 @@ module SecureHeaders
       end
 
       it "does not deduplicate non-matching schema source expressions" do
-        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://*.example.org))
-        expect(csp.value).to eq("default-src *.example.org wss://*.example.org")
+        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://example.example.org))
+        expect(csp.value).to eq("default-src *.example.org wss://example.example.org")
       end
 
       it "creates maximally strict sandbox policy when passed no sandbox token values" do


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [x] ~~Documentation updated~~ N/A

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which? N/A
* What does it do? N/A
* What are the valid values for the header? N/A
* Where does the specification live? N/A

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which? N/A
* What does it do? N/A
* What are the valid values for the directive? N/A



This correct a bug in the `dedup_source_list` function, which causes sources with different protocols to be removed, which breaks possible CSP as headers as the spec only allows for _current protocol_ for schemaless source expressions.

Consider the following `connect-src: *.example.com wss://*.example.com`. This effectively allows for http and websocket connections. The current version of `secure_headers` will minify this to be `connect-src: *.example.com` which only allows for http connections, _disallowing websocket connections_.

The fix here is to check that the schemes match for wildcard sources, using `URI(source).scheme`. For a scheme-less URI like `*.example.com`, the URI will come back with a `scheme` of `nil`, which is fine. There is a step before `dedup_source_list` which strips known schemes like `http`/`https`.