### PR TITLE
Handle different schemes in dedup logic

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -117,7 +117,7 @@ module SecureHeaders
 
     # If a directive contains *, all other values are omitted.
     # If a directive contains 'none' but has other values, 'none' is ommitted.
-    # Schemes are stripped (see http://www.w3.org/TR/CSP2/#match-source-expression)
+    # HTTP Schemes are stripped (see http://www.w3.org/TR/CSP2/#match-source-expression)
     def minify_source_list(directive, source_list)
       source_list = source_list.compact
       if source_list.include?(STAR)
@@ -157,7 +157,7 @@ module SecureHeaders
       if wild_sources.any?
         sources.reject do |source|
           !wild_sources.include?(source) &&
-            wild_sources.any? { |pattern| File.fnmatch(pattern, source) }
+            wild_sources.any? { |pattern| URI.parse(source).scheme == URI.parse(pattern).scheme && File.fnmatch(pattern, source) }
         end
       else
         sources

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -106,6 +106,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
+      it "does not deduplicate any mismatching schemes" do
+        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://whee.example.org example.org))
+        expect(csp.value).to eq("default-src *.example.org wss://whee.example.org example.org")
+      end
+
       it "creates maximally strict sandbox policy when passed no sandbox token values" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: [])
         expect(csp.value).to eq("default-src example.org; sandbox")


### PR DESCRIPTION
closes https://github.com/github/secure_headers/issues/317

## All PRs:

* [X] Has tests
* [ ] Documentation updated - should anything be updated?

## Adding a new header

Generally, adding a new header is always OK.

* Is the header supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the header?
* Where does the specification live?

## Adding a new CSP directive

* Is the directive supported by any user agent? If so, which?
* What does it do?
* What are the valid values for the directive?


## Some questions

* Does this change follow the spec?
* Is `URI.parse` okay? Could it raise? Is there a more performant way to do this?

