### PR TITLE
Add trusted-types and require-trusted-types-for CSP Directive

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -53,7 +53,9 @@ module SecureHeaders
     def build_value
       directives.map do |directive_name|
         case DIRECTIVE_VALUE_TYPES[directive_name]
-        when :source_list, :require_sri_for_list, :require_trusted_types_for_list # require_sri is a simple set of strings that don't need to deal with symbol casing
+        when :source_list,
+             :require_sri_for_list, # require_sri is a simple set of strings that don't need to deal with symbol casing
+             :require_trusted_types_for_list 
           build_source_list_directive(directive_name)
         when :boolean
           symbol_to_hyphen_case(directive_name) if @config.directive_value(directive_name)

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -61,8 +61,18 @@ module SecureHeaders
           build_sandbox_list_directive(directive_name)
         when :media_type_list
           build_media_type_list_directive(directive_name)
+        when :require_trusted_types_for_list
+          build_trusted_type_list_directive(directive_name)
         end
       end.compact.join("; ")
+    end
+
+    def build_trusted_type_list_directive(directive)
+      source_list = @config.directive_value(directive)
+      if source_list && !source_list.empty?
+        escaped_source_list = source_list.gsub(/[\n;]/, " ")
+        [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
+      end
     end
 
     def build_sandbox_list_directive(directive)

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -55,7 +55,7 @@ module SecureHeaders
         case DIRECTIVE_VALUE_TYPES[directive_name]
         when :source_list,
              :require_sri_for_list, # require_sri is a simple set of strings that don't need to deal with symbol casing
-             :require_trusted_types_for_list 
+             :require_trusted_types_for_list
           build_source_list_directive(directive_name)
         when :boolean
           symbol_to_hyphen_case(directive_name) if @config.directive_value(directive_name)

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -53,7 +53,7 @@ module SecureHeaders
     def build_value
       directives.map do |directive_name|
         case DIRECTIVE_VALUE_TYPES[directive_name]
-        when :source_list, :require_sri_for_list # require_sri is a simple set of strings that don't need to deal with symbol casing
+        when :source_list, :require_sri_for_list, :require_trusted_types_for_list # require_sri is a simple set of strings that don't need to deal with symbol casing
           build_source_list_directive(directive_name)
         when :boolean
           symbol_to_hyphen_case(directive_name) if @config.directive_value(directive_name)
@@ -61,8 +61,6 @@ module SecureHeaders
           build_sandbox_list_directive(directive_name)
         when :media_type_list
           build_media_type_list_directive(directive_name)
-        when :require_trusted_types_for_list
-          build_trusted_type_list_directive(directive_name)
         end
       end.compact.join("; ")
     end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -65,14 +65,6 @@ module SecureHeaders
       end.compact.join("; ")
     end
 
-    def build_trusted_type_list_directive(directive)
-      source_list = @config.directive_value(directive)
-      if source_list && !source_list.empty?
-        escaped_source_list = source_list.gsub(/[\n;]/, " ")
-        [symbol_to_hyphen_case(directive), escaped_source_list].join(" ").strip
-      end
-    end
-
     def build_sandbox_list_directive(directive)
       return unless sandbox_list = @config.directive_value(directive)
       max_strict_policy = case sandbox_list

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -35,6 +35,7 @@ module SecureHeaders
       @report_only = nil
       @report_uri = nil
       @require_sri_for = nil
+      @require_trusted_types_for = nil
       @sandbox = nil
       @script_nonce = nil
       @script_src = nil
@@ -44,6 +45,7 @@ module SecureHeaders
       @style_src = nil
       @style_src_elem = nil
       @style_src_attr = nil
+      @trusted_types = nil
       @worker_src = nil
       @upgrade_insecure_requests = nil
       @disable_nonce_backwards_compatibility = nil

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "set"
-require 'byebug'
 
 module SecureHeaders
   module PolicyManagement

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -398,7 +398,7 @@ module SecureHeaders
       def validate_require_trusted_types_for_source_expression!(directive, require_trusted_types_for_expression)
         ensure_array_of_strings!(directive, require_trusted_types_for_expression)
         unless require_trusted_types_for_expression.to_set.subset?(REQUIRE_TRUSTED_TYPES_FOR_VALUES)
-          raise ContentSecurityPolicyConfigError.new(%(require-sri for must be a subset of #{REQUIRE_TRUSTED_TYPES_FOR_VALUES.to_a} but was #{require_trusted_types_for_expression}))
+          raise ContentSecurityPolicyConfigError.new(%(require-trusted-types-for for must be a subset of #{REQUIRE_TRUSTED_TYPES_FOR_VALUES.to_a} but was #{require_trusted_types_for_expression}))
         end
       end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "set"
+require 'byebug'
 
 module SecureHeaders
   module PolicyManagement
@@ -98,7 +99,19 @@ module SecureHeaders
       STYLE_SRC_ATTR
     ].flatten.freeze
 
-    ALL_DIRECTIVES = (DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0).uniq.sort
+    # Experimental directives - these vary greatly in support
+    # See MDN for details.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types
+    TRUSTED_TYPES = :trusted_types
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
+    REQUIRE_TRUSTED_TYPES_FOR = :require_trusted_types_for
+
+    DIRECTIVES_EXPERIMENTAL = [
+      TRUSTED_TYPES,
+      REQUIRE_TRUSTED_TYPES_FOR,
+    ].flatten.freeze
+
+    ALL_DIRECTIVES = (DIRECTIVES_1_0 + DIRECTIVES_2_0 + DIRECTIVES_3_0 + DIRECTIVES_EXPERIMENTAL).uniq.sort
 
     # Think of default-src and report-uri as the beginning and end respectively,
     # everything else is in between.
@@ -121,6 +134,7 @@ module SecureHeaders
       OBJECT_SRC                => :source_list,
       PLUGIN_TYPES              => :media_type_list,
       REQUIRE_SRI_FOR           => :require_sri_for_list,
+      REQUIRE_TRUSTED_TYPES_FOR => :require_trusted_types_for_list,
       REPORT_URI                => :source_list,
       PREFETCH_SRC              => :source_list,
       SANDBOX                   => :sandbox_list,
@@ -130,6 +144,7 @@ module SecureHeaders
       STYLE_SRC                 => :source_list,
       STYLE_SRC_ELEM            => :source_list,
       STYLE_SRC_ATTR            => :source_list,
+      TRUSTED_TYPES             => :source_list,
       WORKER_SRC                => :source_list,
       UPGRADE_INSECURE_REQUESTS => :boolean,
     }.freeze
@@ -175,6 +190,7 @@ module SecureHeaders
     ].freeze
 
     REQUIRE_SRI_FOR_VALUES = Set.new(%w(script style))
+    REQUIRE_TRUSTED_TYPES_FOR_VALUES = Set.new(%w(script))
 
     module ClassMethods
       # Public: generate a header name, value array that is user-agent-aware.
@@ -325,6 +341,8 @@ module SecureHeaders
           validate_media_type_expression!(directive, value)
         when :require_sri_for_list
           validate_require_sri_source_expression!(directive, value)
+        when :require_trusted_types_for_list
+          validate_require_trusted_types_for_source_expression!(directive, value)
         else
           raise ContentSecurityPolicyConfigError.new("Unknown directive #{directive}")
         end
@@ -366,6 +384,16 @@ module SecureHeaders
         ensure_array_of_strings!(directive, require_sri_for_expression)
         unless require_sri_for_expression.to_set.subset?(REQUIRE_SRI_FOR_VALUES)
           raise ContentSecurityPolicyConfigError.new(%(require-sri for must be a subset of #{REQUIRE_SRI_FOR_VALUES.to_a} but was #{require_sri_for_expression}))
+        end
+      end
+
+      # Private: validates that a require trusted types for expression:
+      # 1. is an array of strings
+      # 2. is a subset of ["script"]
+      def validate_require_trusted_types_for_source_expression!(directive, require_trusted_types_for_expression)
+        ensure_array_of_strings!(directive, require_trusted_types_for_expression)
+        unless require_trusted_types_for_expression.to_set.subset?(REQUIRE_TRUSTED_TYPES_FOR_VALUES)
+          raise ContentSecurityPolicyConfigError.new(%(require-sri for must be a subset of #{REQUIRE_TRUSTED_TYPES_FOR_VALUES.to_a} but was #{require_trusted_types_for_expression}))
         end
       end
 

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -286,7 +286,8 @@ module SecureHeaders
         source_list?(directive) ||
           sandbox_list?(directive) ||
           media_type_list?(directive) ||
-          require_sri_for_list?(directive)
+          require_sri_for_list?(directive) ||
+          require_trusted_types_for_list?(directive)
       end
 
       # For each directive in additions that does not exist in the original config,
@@ -322,6 +323,10 @@ module SecureHeaders
 
       def require_sri_for_list?(directive)
         DIRECTIVE_VALUE_TYPES[directive] == :require_sri_for_list
+      end
+
+      def require_trusted_types_for_list?(directive)
+        DIRECTIVE_VALUE_TYPES[directive] == :require_trusted_types_for_list
       end
 
       # Private: Validates that the configuration has a valid type, or that it is a valid

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -151,10 +151,6 @@ module SecureHeaders
         expect(csp.value).to eq("default-src 'self'; require-trusted-types-for script")
       end
 
-      it "does not support style for require-trusted-types-for directive" do
-        expect { ContentSecurityPolicy.new({require_trusted_types_for: %(script style)}) }.to raise_error(ContentSecurityPolicyConfigError)
-      end
-
       it "includes prefetch-src" do
         csp = ContentSecurityPolicy.new(default_src: %w('self'), prefetch_src: %w(foo.com))
         expect(csp.value).to eq("default-src 'self'; prefetch-src foo.com")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -146,6 +146,15 @@ module SecureHeaders
         expect(csp.value).to eq("default-src 'self'; require-sri-for script style")
       end
 
+      it "supports require-trusted-types-for directive" do
+        csp = ContentSecurityPolicy.new({require_trusted_types_for: %(script)})
+        expect(csp.value).to eq("require-trusted-types-for script")
+      end
+
+      it "does not support style for require-trusted-types-for directive" do
+        expect { ContentSecurityPolicy.new({require_trusted_types_for: %(script style)}) }.to raise_error(ContentSecurityPolicyConfigError)
+      end
+
       it "includes prefetch-src" do
         csp = ContentSecurityPolicy.new(default_src: %w('self'), prefetch_src: %w(foo.com))
         expect(csp.value).to eq("default-src 'self'; prefetch-src foo.com")
@@ -184,6 +193,11 @@ module SecureHeaders
       it "supports style-src-attr directive" do
         csp = ContentSecurityPolicy.new({style_src: %w('self'), style_src_attr: %w('self')})
         expect(csp.value).to eq("style-src 'self'; style-src-attr 'self'")
+      end
+
+      it "supports trusted-types directive" do
+        csp = ContentSecurityPolicy.new({trusted_types: %w(blahblahpolicy)})
+        expect(csp.value).to eq("trusted-types blahblahpolicy")
       end
     end
   end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -146,7 +146,7 @@ module SecureHeaders
         expect(csp.value).to eq("default-src 'self'; require-sri-for script style")
       end
 
-      it "supports require-trusted-types-for directive" do
+      it "allows style as a require-trusted-types-src" do
         csp = ContentSecurityPolicy.new(default_src: %w('self'), require_trusted_types_for: %w(script))
         expect(csp.value).to eq("default-src 'self'; require-trusted-types-for script")
       end
@@ -194,6 +194,11 @@ module SecureHeaders
       it "supports trusted-types directive" do
         csp = ContentSecurityPolicy.new({trusted_types: %w(blahblahpolicy)})
         expect(csp.value).to eq("trusted-types blahblahpolicy")
+      end
+
+      it "allows duplicate policy names in trusted-types directive" do
+        csp = ContentSecurityPolicy.new({trusted_types: %w(blahblahpolicy 'allow-duplicates')})
+        expect(csp.value).to eq("trusted-types blahblahpolicy 'allow-duplicates'")
       end
     end
   end

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -196,6 +196,11 @@ module SecureHeaders
         expect(csp.value).to eq("trusted-types blahblahpolicy")
       end
 
+      it "supports trusted-types directive with 'none'" do
+        csp = ContentSecurityPolicy.new({trusted_types: %w(none)})
+        expect(csp.value).to eq("trusted-types none")
+      end
+
       it "allows duplicate policy names in trusted-types directive" do
         csp = ContentSecurityPolicy.new({trusted_types: %w(blahblahpolicy 'allow-duplicates')})
         expect(csp.value).to eq("trusted-types blahblahpolicy 'allow-duplicates'")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -147,8 +147,8 @@ module SecureHeaders
       end
 
       it "supports require-trusted-types-for directive" do
-        csp = ContentSecurityPolicy.new({require_trusted_types_for: %(script)})
-        expect(csp.value).to eq("require-trusted-types-for script")
+        csp = ContentSecurityPolicy.new(default_src: %w('self'), require_trusted_types_for: %(script))
+        expect(csp.value).to eq("default-src 'self'; require-trusted-types-for script")
       end
 
       it "does not support style for require-trusted-types-for directive" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -147,7 +147,7 @@ module SecureHeaders
       end
 
       it "supports require-trusted-types-for directive" do
-        csp = ContentSecurityPolicy.new(default_src: %w('self'), require_trusted_types_for: %(script))
+        csp = ContentSecurityPolicy.new(default_src: %w('self'), require_trusted_types_for: %w(script))
         expect(csp.value).to eq("default-src 'self'; require-trusted-types-for script")
       end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -146,7 +146,7 @@ module SecureHeaders
         expect(csp.value).to eq("default-src 'self'; require-sri-for script style")
       end
 
-      it "allows style as a require-trusted-types-src" do
+      it "allows style as a require-trusted-types-for source" do
         csp = ContentSecurityPolicy.new(default_src: %w('self'), require_trusted_types_for: %w(script))
         expect(csp.value).to eq("default-src 'self'; require-trusted-types-for script")
       end

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -122,6 +122,12 @@ module SecureHeaders
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
+      it "rejects style for trusted types" do
+        expect do
+          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(style_src: %w('self'), require_trusted_types_for: %w(script style), trusted_types: %w(abcpolicy))))
+        end
+      end
+
       # this is mostly to ensure people don't use the antiquated shorthands common in other configs
       it "performs light validation on source lists" do
         expect do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -45,6 +45,7 @@ module SecureHeaders
           plugin_types: %w(application/x-shockwave-flash),
           prefetch_src: %w(fetch.com),
           require_sri_for: %w(script style),
+          require_trusted_types_for: %w(script),
           script_src: %w('self'),
           style_src: %w('unsafe-inline'),
           upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/
@@ -53,6 +54,7 @@ module SecureHeaders
           script_src_attr: %w(example.com),
           style_src_elem: %w(example.com),
           style_src_attr: %w(example.com),
+          trusted_types: %w(abcpolicy),
 
           report_uri: %w(https://example.com/uri-directive),
         }


### PR DESCRIPTION
## All PRs:

* [x] Has tests
* [ ] Documentation updated

## Adding a new CSP directive

This PR adds support for the [TrustedTypes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types) CSP directives, [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) and 'trusted-types'.

* Is the directive supported by any user agent? If so, which?
TrustedTypes are available in [Chrome 83, Edge 83](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types#browser_compatibility) and a [polyfill](https://github.com/w3c/webappsec-trusted-types#polyfill) exists for browsers that don't currently support.
* What does it do?
`require-trusted-types-for` disallows using strings with DOM XSS [injection sink functions](https://w3c.github.io/webappsec-trusted-types/dist/spec/#injection-sinks) (functions like Document.write, Element.InnerHtml), and requires matching types [created by Trusted Type policies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for#examples). 

* What are the valid values for the directive
`require-trusted-types-for`  only allows `script`. 
`trusted-types` allows a list of strings, including one `'allow-duplicates'` which allows multiples of the same named policy to be created.

