### PR TITLE
fix source dedup breaking with port wildcards

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -154,10 +154,10 @@ module SecureHeaders
     # e.g. *.github.com asdf.github.com becomes *.github.com
     def dedup_source_list(sources)
       sources = sources.uniq
-      wild_sources = sources.select { |source| source =~ STAR_REGEXP }
+      wild_sources = sources.select { |source| source =~ DOMAIN_WILDCARD_REGEX || source =~ PORT_WILDCARD_REGEX }
 
       if wild_sources.any?
-        schemes = sources.map { |source| [source, URI(source).scheme] }.to_h
+        schemes = sources.map { |source| [source, source_scheme(source)] }.to_h
         sources.reject do |source|
           !wild_sources.include?(source) &&
             wild_sources.any? { |pattern| schemes[pattern] == schemes[source] && File.fnmatch(pattern, source) }
@@ -211,6 +211,14 @@ module SecureHeaders
 
     def symbol_to_hyphen_case(sym)
       sym.to_s.tr("_", "-")
+    end
+
+    def source_scheme(source)
+      uri = URI(source.sub(PORT_WILDCARD_REGEX, ""))
+      # If host is nil the given source doesn't contain a scheme
+      # e.g. for `example.org:443` it would return `example.org` as the scheme
+      # which is of course incorrect
+      uri.scheme if uri.host
     end
   end
 end

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -152,7 +152,8 @@ module SecureHeaders
 
     FETCH_SOURCES = ALL_DIRECTIVES - NON_FETCH_SOURCES - NON_SOURCE_LIST_SOURCES
 
-    STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
+    DOMAIN_WILDCARD_REGEX = /(?<=\A|[^:])\*/
+    PORT_WILDCARD_REGEX = /:\*/
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
 
     WILDCARD_SOURCES = [

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -56,6 +56,16 @@ module SecureHeaders
         expect(csp.value).to eq("default-src *.example.org")
       end
 
+      it "minifies overlapping port wildcards" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org:* example.org:443 https://example.org:80))
+        expect(csp.value).to eq("default-src example.org example.org:*")
+      end
+
+      it "allows for port wildcards" do
+        csp = ContentSecurityPolicy.new(connect_src: %w(ws://localhost:*))
+        expect(csp.value).to eq("connect-src ws://localhost:*")
+      end
+
       it "removes http/s schemes from hosts" do
         csp = ContentSecurityPolicy.new(default_src: %w(https://example.org))
         expect(csp.value).to eq("default-src example.org")
@@ -102,7 +112,8 @@ module SecureHeaders
       end
 
       it "deduplicates any source expressions" do
-        csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org example.org))
+        src = %w(example.org example.org http://example.org https://example.org)
+        csp = ContentSecurityPolicy.new(default_src: src)
         expect(csp.value).to eq("default-src example.org")
       end
 


### PR DESCRIPTION
Fixes the bug introduced with release v6.3.4 in #478 that causes errors like the following when using port wildcards such as `ws://localhost:*` in one's sources:

```
2022-06-29 08:56:52 +0100 Rack app ("GET /" - (::1)): #<URI::InvalidURIError: bad URI(is not URI?): "ws://localhost:*">
2022-06-29 08:56:52 +0100 Rack app ("GET /favicon.ico" - (::1)): #<URI::InvalidURIError: bad URI(is not URI?): "ws://localhost:*">
```
