### PR TITLE
Use SPDX license code and swap summary & description

### DIFF
--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -9,12 +9,12 @@ Gem::Specification.new do |gem|
   gem.version       = SecureHeaders::VERSION
   gem.authors       = ["Neil Matatall"]
   gem.email         = ["neil.matatall@gmail.com"]
-  gem.description   = "Manages application of security headers with many safe defaults."
-  gem.summary       = 'Add easily configured security headers to responses
+  gem.summary       = "Manages application of security headers with many safe defaults."
+  gem.description   = 'Add easily configured security headers to responses
     including content-security-policy, x-frame-options,
     strict-transport-security, etc.'
   gem.homepage      = "https://github.com/twitter/secureheaders"
-  gem.license       = "Apache Public License 2.0"
+  gem.license       = "Apache-2.0"
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Using an SPDX code makes automatic processing easier. The summary should be shorter than the description.

## All PRs:

These are irrelevant since it's metadata.

* [ ] Has tests
* [ ] Documentation updated
