### PR TITLE
Trusted types: Use single-quoted `'script'`.

### DIFF
--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -189,7 +189,7 @@ module SecureHeaders
     ].freeze
 
     REQUIRE_SRI_FOR_VALUES = Set.new(%w(script style))
-    REQUIRE_TRUSTED_TYPES_FOR_VALUES = Set.new(%w(script))
+    REQUIRE_TRUSTED_TYPES_FOR_VALUES = Set.new(%w('script'))
 
     module ClassMethods
       # Public: generate a header name, value array that is user-agent-aware.
@@ -393,7 +393,7 @@ module SecureHeaders
 
       # Private: validates that a require trusted types for expression:
       # 1. is an array of strings
-      # 2. is a subset of ["script"]
+      # 2. is a subset of ["'script'"]
       def validate_require_trusted_types_for_source_expression!(directive, require_trusted_types_for_expression)
         ensure_array_of_strings!(directive, require_trusted_types_for_expression)
         unless require_trusted_types_for_expression.to_set.subset?(REQUIRE_TRUSTED_TYPES_FOR_VALUES)

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -197,8 +197,8 @@ module SecureHeaders
       end
 
       it "supports trusted-types directive with 'none'" do
-        csp = ContentSecurityPolicy.new({trusted_types: %w(none)})
-        expect(csp.value).to eq("trusted-types none")
+        csp = ContentSecurityPolicy.new({trusted_types: %w('none')})
+        expect(csp.value).to eq("trusted-types 'none'")
       end
 
       it "allows duplicate policy names in trusted-types directive" do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -45,7 +45,7 @@ module SecureHeaders
           plugin_types: %w(application/x-shockwave-flash),
           prefetch_src: %w(fetch.com),
           require_sri_for: %w(script style),
-          require_trusted_types_for: %w(script),
+          require_trusted_types_for: %w('script'),
           script_src: %w('self'),
           style_src: %w('unsafe-inline'),
           upgrade_insecure_requests: true, # see https://www.w3.org/TR/upgrade-insecure-requests/


### PR DESCRIPTION
Unlike e.g. `require-sri-for` (which our previous implementation for), the `require-trusted-types-for` directive uses:

- Single-quoted `'script'` and `'none'` sources (in addition to `'allow-duplicates'`).
- Unquoted policies in addition to those.

See:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-sri-for
- https://w3c.github.io/webappsec-trusted-types/dist/spec/#require-trusted-types-for-csp-directive

Right now we are flexible about both quoted and unquoted sources, but this PR starts by using the values used for the directive per spec / browser implementations.

## All PRs:

* [x] Has tests
* [ ] Documentation updated
