### PR TITLE
Set license code in metadata to MIT

### DIFF
--- a/secure_headers.gemspec
+++ b/secure_headers.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
     including content-security-policy, x-frame-options,
     strict-transport-security, etc.'
   gem.homepage      = "https://github.com/twitter/secureheaders"
-  gem.license       = "Apache-2.0"
+  gem.license       = "MIT"
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
In https://github.com/github/secure_headers/pull/315 (5638cb03344a8b5f02024735143d2261cff08a94) the gem was relicensed to MIT, but it was incomplete. 86c762aea480d0a776246652586f93e026f6799f at least fixed the README, but the gemspec itself was still forgotten.

Follow up to https://github.com/github/secure_headers/pull/493#discussion_r942911282

## All PRs:

* [ ] Has tests
* [ ] Documentation updated