### PR TITLE
Semantically parse and deduplicate source expressions

### DIFF
--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -162,9 +162,10 @@ module SecureHeaders
       wildcard_host_source_expressions = host_source_expressions.select { |source| source.has_wildcard? }
       
       if wildcard_host_source_expressions.any?
-        host_source_expressions.reject do |source|
+        filtered = host_source_expressions.reject do |source|
             wildcard_host_source_expressions.any? { |wilcard_source| wildcard_source.matches_same_or_superset?(source) }
         end
+        filtered.map { |source| source.to_s }
       else
         sources
       end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -163,7 +163,7 @@ module SecureHeaders
       
       if wildcard_host_source_expressions.any?
         filtered = host_source_expressions.reject do |source|
-            wildcard_host_source_expressions.any? { |wilcard_source| wildcard_source.matches_same_or_superset?(source) }
+            wildcard_host_source_expressions.any? { |wildcard_source| wildcard_source.matches_same_or_superset?(source) }
         end
         filtered.map { |source| source.to_s }
       else

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "policy_management"
 require_relative "content_security_policy_config"
-require_relative "csp_host_source_expression"
+require_relative "content_security_policy/source_expression"
 
 module SecureHeaders
   class ContentSecurityPolicy
@@ -157,12 +157,13 @@ module SecureHeaders
     # e.g. *.github.com asdf.github.com becomes *.github.com
     def dedup_source_list(sources)
       sources = sources.uniq
-      host_source_expressions = sources.map { |source| SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(source) }
+      host_source_expressions = sources.map { |source| parse_source_expression(source) }
+      # TODO: Split by source expression type.
       wildcard_host_source_expressions = host_source_expressions.select { |source| source.has_wildcard? }
       
       if wildcard_host_source_expressions.any?
         host_source_expressions.reject do |source|
-            wildcard_host_source_expressions.any? { |wilcard_source| wildcard_source.matches_superset?(source) }
+            wildcard_host_source_expressions.any? { |wilcard_source| wildcard_source.matches_same_or_superset?(source) }
         end
       else
         sources

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require_relative "policy_management"
 require_relative "content_security_policy_config"
-require_relative "content_security_policy/source_expression"
+require_relative "content_security_policy/parse_source_expression"
 
 module SecureHeaders
   class ContentSecurityPolicy

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -110,9 +110,7 @@ module SecureHeaders
       source_list = @config.directive_value(directive)
       if source_list != OPT_OUT && source_list && source_list.any?
         cleaned_source_list = clean_deprecated_chars(directive, source_list)
-        puts "cleaned_source_list: #{cleaned_source_list}"
         minified_source_list = minify_source_list(directive, cleaned_source_list).join(" ")
-        puts "minified_source_list: #{minified_source_list}"
         [symbol_to_hyphen_case(directive), minified_source_list].join(" ").strip
       end
     end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -157,7 +157,7 @@ module SecureHeaders
     # e.g. *.github.com asdf.github.com becomes *.github.com
     def dedup_source_list(sources)
       sources = sources.uniq
-      host_source_expressions = sources.map SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse
+      host_source_expressions = sources.map { |source| SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(source) }
       wildcard_host_source_expressions = host_source_expressions.select { |source| source.has_wildcard? }
       
       if wildcard_host_source_expressions.any?

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -114,7 +114,7 @@ module SecureHeaders
         [symbol_to_hyphen_case(directive), minified_source_list].join(" ").strip
       end
     end
-    
+
     # Private: Calculates a modified version version of source_list:
     # - where any expression containing a deprecated character (semicolon or newline) has been split by that
     # character, and
@@ -134,7 +134,7 @@ module SecureHeaders
           cleaned_source_list.append(expression)
         end
       end
-      cleaned_source_list.select{ | value | value != "" }
+      cleaned_source_list.select { |value| value != "" }
     end
 
     # If a directive contains *, all other values are omitted.
@@ -177,7 +177,7 @@ module SecureHeaders
       host_source_expressions = sources.map { |source| parse_source_expression(source) }
       # TODO: Split by source expression type.
       wildcard_host_source_expressions = host_source_expressions.select { |source| source.has_wildcard? }
-      
+
       filtered = host_source_expressions.select do |source|
         wildcard_host_source_expressions.none? { |wildcard_source| wildcard_source != source && wildcard_source.matches_same_or_superset?(source) }
       end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -216,8 +216,7 @@ module SecureHeaders
     end
 
     def source_scheme(source)
-      match = source.match(/^([A-Za-z0-9\-\+.]+):\/\//)
-      match ? match[1] : nil
+      source.match(/^([A-Za-z0-9\-\+.]+):\/\//)&.values_at(1)
     end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -216,11 +216,8 @@ module SecureHeaders
     end
 
     def source_scheme(source)
-      uri = URI(source.sub(PORT_WILDCARD_REGEX, ""))
-      # If host is nil the given source doesn't contain a scheme
-      # e.g. for `example.org:443` it would return `example.org` as the scheme
-      # which is of course incorrect
-      uri.scheme if uri.host
+      match = source.match(/^([A-Za-z0-9\-\+.]+):\/\//)
+      match ? match[1] : nil
     end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -117,8 +117,8 @@ module SecureHeaders
               Kernel.warn("#{directive} contains a #{$1} in #{source_list.join(" ").inspect} which will raise an error in future versions. It has been replaced with a blank space.")
               semicolon_warned_yet = true
             end
-            split_entry = entry.split(/\n|;/)
-            cleaned_source_list.append(split_entry)
+            split_entry = entry.split(/\n|;/).select{ | value | value != "" }
+            cleaned_source_list.concat(split_entry)
           else
             cleaned_source_list.append(entry)
           end

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "policy_management"
 require_relative "content_security_policy_config"
+require_relative "csp_host_source_expression"
 
 module SecureHeaders
   class ContentSecurityPolicy
@@ -156,6 +157,7 @@ module SecureHeaders
     # e.g. *.github.com asdf.github.com becomes *.github.com
     def dedup_source_list(sources)
       sources = sources.uniq
+      host_source_expressions = sources.map SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse
       wild_sources = sources.select { |source| source =~ DOMAIN_WILDCARD_REGEX || source =~ PORT_WILDCARD_REGEX }
 
       if wild_sources.any?

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -161,14 +161,17 @@ module SecureHeaders
       # TODO: Split by source expression type.
       wildcard_host_source_expressions = host_source_expressions.select { |source| source.has_wildcard? }
       
-      if wildcard_host_source_expressions.any?
-        filtered = host_source_expressions.reject do |source|
-            wildcard_host_source_expressions.any? { |wildcard_source| wildcard_source.matches_same_or_superset?(source) }
-        end
-        filtered.map { |source| source.to_s }
-      else
-        sources
+      filtered = host_source_expressions.select do |source|
+        wildcard_host_source_expressions.none? { |wildcard_source| wildcard_source != source && wildcard_source.matches_same_or_superset?(source) }
       end
+
+      # if wildcard_host_source_expressions.any?
+      puts "--filtered---\n\n"
+      puts filtered
+      puts "---filtered2--\n\n"
+      filtered.map { |source| source.to_s }
+      puts "---filtered3--\n\n"
+      filtered.map { |source| source.to_s }
     end
 
     # Private: append a nonce to the script/style directories if script_nonce

--- a/lib/secure_headers/headers/content_security_policy.rb
+++ b/lib/secure_headers/headers/content_security_policy.rb
@@ -109,8 +109,10 @@ module SecureHeaders
     def build_source_list_directive(directive)
       source_list = @config.directive_value(directive)
       if source_list != OPT_OUT && source_list && source_list.any?
-        cleaned_source_list = clean_deprecated_chars(source_list)
+        cleaned_source_list = clean_deprecated_chars(directive, source_list)
+        puts "cleaned_source_list: #{cleaned_source_list}"
         minified_source_list = minify_source_list(directive, cleaned_source_list).join(" ")
+        puts "minified_source_list: #{minified_source_list}"
         [symbol_to_hyphen_case(directive), minified_source_list].join(" ").strip
       end
     end
@@ -118,7 +120,7 @@ module SecureHeaders
     # Private: Calculates a modified version version of source_list where any
     # expression containing a deprecated character has been split by that
     # character.
-    def clean_deprecated_chars(source_list)
+    def clean_deprecated_chars(directive, source_list)
       cleaned_source_list = []
       semicolon_warned_yet = false
       source_list.map do |expression|

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -3,7 +3,6 @@
 module SecureHeaders
   class ContentSecurityPolicy
     class HostSourceExpression
-
       attr_reader :scheme, :host_pattern, :port_pattern, :path
 
       def initialize(scheme: nil, host_pattern:, port_pattern: nil, path: nil)
@@ -27,7 +26,7 @@ module SecureHeaders
       end
 
       # Example: *.example.com matches *.subdomain.example.com
-      def matches_superset?(other_source)
+      def matches_same_or_superset?(other_source)
         # A conservative interpretation of https://w3c.github.io/webappsec-csp/#match-url-to-source-expression
         return false unless @scheme.nil? || @scheme == other_source.scheme
         return false unless File.fnmatch(@host_pattern, other_source.host_pattern)
@@ -80,12 +79,3 @@ module SecureHeaders
     end
   end
 end
-
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
-# s.to_str
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
-# puts "\n\ns: #{s.to_str}\n\n"
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require_relative "source_expression"
+
 module SecureHeaders
   class ContentSecurityPolicy
-    class HostSourceExpression
+    class HostSourceExpression < SourceExpression
       attr_reader :scheme, :host_pattern, :port_pattern, :path
 
-      def initialize(scheme: nil, host_pattern:, port_pattern: nil, path: nil)
+      def initialize(scheme: nil, host_pattern: "", port_pattern: nil, path: nil)
         @scheme = scheme
         @host_pattern = host_pattern
         @port_pattern = port_pattern
@@ -43,11 +45,13 @@ module SecureHeaders
         pathB.start_with?(pathA)
       end
 
-      def self.parse(s)
+      def self.try_parse(s)
+        puts "------hosty--"
         puts "--------"
         
         # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
         scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):\/\/)?(?<rest>.*)\z/)
+        return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         after_scheme = scheme_match[:rest]
         puts "scheme: #{scheme}"
@@ -55,6 +59,7 @@ module SecureHeaders
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         host_match = after_scheme.match(/\A(?<host_pattern>(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*|\*)(?<rest>.*)\z/)
+        return nil if host_match.nil?
         host_pattern = host_match[:host_pattern]
         after_host = host_match[:rest]
         puts "host_pattern: #{host_pattern}"
@@ -62,6 +67,7 @@ module SecureHeaders
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         port_match = after_host.match(/\A(:(?<port>[[:digit:]]+|\*))?(?<rest>.*)\z/)
+        return nil if port_match.nil?
         port_pattern = port_match[:port]
         after_port = port_match[:rest]
         puts "port_pattern: #{port_pattern}"
@@ -70,6 +76,7 @@ module SecureHeaders
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
         path_match = after_port.match(/\A(?<path>(\/[^;:]*)?)\z/)
+        return nil if path_match.nil?
         path = path_match[:path]
         puts "path: #{path}"
 

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -32,7 +32,7 @@ module SecureHeaders
         # It's:
         # - okay to have some false negatives (i.e. incorrectly return `false`), since this is only used to optimize deduplication,
         # - as long as we don't have false positives (i.e. incorrectly return `true`).
-        return false unless @scheme.nil? || @scheme == other_source.scheme
+        return false unless @scheme == other_source.scheme
         return false unless File.fnmatch(@host_pattern, other_source.host_pattern)
         return false unless @port_pattern.nil? || @port_pattern == "*" || @port_pattern = other_source.port_pattern
         # Based on https://w3c.github.io/webappsec-csp/#path-part-match without percent-decoding.

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -12,7 +12,7 @@ module SecureHeaders
         @path = path
       end
 
-      def to_str
+      def to_s
         output = @host_pattern
         output = @scheme + "://" + output if @scheme
         output += ":" + @port_pattern if @port_pattern
@@ -54,7 +54,7 @@ module SecureHeaders
         puts "after_scheme: #{after_scheme}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
-        host_match = after_scheme.match(/\A(?<host_pattern>\*|(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*)(?<rest>.*)\z/)
+        host_match = after_scheme.match(/\A(?<host_pattern>(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*|\*)(?<rest>.*)\z/)
         host_pattern = host_match[:host_pattern]
         after_host = host_match[:rest]
         puts "host_pattern: #{host_pattern}"

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -36,7 +36,7 @@ module SecureHeaders
         # - as long as we don't have false positives (i.e. incorrectly return `true`).
         return false unless @scheme == other_source.scheme
         return false unless File.fnmatch(@host_pattern, other_source.host_pattern)
-        return false unless @port_pattern.nil? || @port_pattern == "*" || @port_pattern = other_source.port_pattern
+        return false unless @port_pattern == "*" || @port_pattern == other_source.port_pattern
         # Based on https://w3c.github.io/webappsec-csp/#path-part-match without percent-decoding.
         pathA = @path
         pathB = other_source.path
@@ -46,30 +46,39 @@ module SecureHeaders
       end
 
       def self.try_parse(s)
+        puts "------hosty--"
+        puts "--------"
         
         # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
         scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):\/\/)?(?<rest>.*)\z/)
         return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         after_scheme = scheme_match[:rest]
+        puts "scheme: #{scheme}"
+        puts "after_scheme: #{after_scheme}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         host_match = after_scheme.match(/\A(?<host_pattern>(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*|\*)(?<rest>.*)\z/)
         return nil if host_match.nil?
         host_pattern = host_match[:host_pattern]
         after_host = host_match[:rest]
+        puts "host_pattern: #{host_pattern}"
+        puts "after_host: #{after_host}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         port_match = after_host.match(/\A(:(?<port>[[:digit:]]+|\*))?(?<rest>.*)\z/)
         return nil if port_match.nil?
         port_pattern = port_match[:port]
         after_port = port_match[:rest]
+        puts "port_pattern: #{port_pattern}"
+        puts "after_port: #{after_port}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
         path_match = after_port.match(/\A(?<path>(\/[^;,\n]*)?)\z/)
         return nil if path_match.nil?
         path = path_match[:path]
+        puts "path: #{path}"
 
         new(
           scheme: scheme,

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -22,7 +22,7 @@ module SecureHeaders
 
       # The host or scheme can contain a wildcard
       def has_wildcard?
-        @host_pattern.start_with("*") || @port_pattern == "*"
+        @host_pattern.start_with?("*") || @port_pattern == "*"
       end
 
       # Example: *.example.com matches *.subdomain.example.com

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -75,7 +75,7 @@ module SecureHeaders
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
-        path_match = after_port.match(/\A(?<path>(\/[^;:]*)?)\z/)
+        path_match = after_port.match(/\A(?<path>(\/[^;,\n]*)?)\z/)
         return nil if path_match.nil?
         path = path_match[:path]
         puts "path: #{path}"

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -46,39 +46,30 @@ module SecureHeaders
       end
 
       def self.try_parse(s)
-        puts "------hosty--"
-        puts "--------"
         
         # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
         scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):\/\/)?(?<rest>.*)\z/)
         return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         after_scheme = scheme_match[:rest]
-        puts "scheme: #{scheme}"
-        puts "after_scheme: #{after_scheme}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         host_match = after_scheme.match(/\A(?<host_pattern>(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*|\*)(?<rest>.*)\z/)
         return nil if host_match.nil?
         host_pattern = host_match[:host_pattern]
         after_host = host_match[:rest]
-        puts "host_pattern: #{host_pattern}"
-        puts "after_host: #{after_host}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         port_match = after_host.match(/\A(:(?<port>[[:digit:]]+|\*))?(?<rest>.*)\z/)
         return nil if port_match.nil?
         port_pattern = port_match[:port]
         after_port = port_match[:rest]
-        puts "port_pattern: #{port_pattern}"
-        puts "after_port: #{after_port}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
         path_match = after_port.match(/\A(?<path>(\/[^;,\n]*)?)\z/)
         return nil if path_match.nil?
         path = path_match[:path]
-        puts "path: #{path}"
 
         new(
           scheme: scheme,

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -46,39 +46,29 @@ module SecureHeaders
       end
 
       def self.try_parse(s)
-        puts "------hosty--"
-        puts "--------"
-        
         # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
         scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):\/\/)?(?<rest>.*)\z/)
         return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         after_scheme = scheme_match[:rest]
-        puts "scheme: #{scheme}"
-        puts "after_scheme: #{after_scheme}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         host_match = after_scheme.match(/\A(?<host_pattern>(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*|\*)(?<rest>.*)\z/)
         return nil if host_match.nil?
         host_pattern = host_match[:host_pattern]
         after_host = host_match[:rest]
-        puts "host_pattern: #{host_pattern}"
-        puts "after_host: #{after_host}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         port_match = after_host.match(/\A(:(?<port>[[:digit:]]+|\*))?(?<rest>.*)\z/)
         return nil if port_match.nil?
         port_pattern = port_match[:port]
         after_port = port_match[:rest]
-        puts "port_pattern: #{port_pattern}"
-        puts "after_port: #{after_port}"
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
         path_match = after_port.match(/\A(?<path>(\/[^;,\n]*)?)\z/)
         return nil if path_match.nil?
         path = path_match[:path]
-        puts "path: #{path}"
 
         new(
           scheme: scheme,

--- a/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/host_source_expression.rb
@@ -27,7 +27,11 @@ module SecureHeaders
 
       # Example: *.example.com matches *.subdomain.example.com
       def matches_same_or_superset?(other_source)
-        # A conservative interpretation of https://w3c.github.io/webappsec-csp/#match-url-to-source-expression
+        return false unless other_source.is_a?(HostSourceExpression)
+        # A pared-down version of https://w3c.github.io/webappsec-csp/#match-url-to-source-expression
+        # It's:
+        # - okay to have some false negatives (i.e. incorrectly return `false`), since this is only used to optimize deduplication,
+        # - as long as we don't have false positives (i.e. incorrectly return `true`).
         return false unless @scheme.nil? || @scheme == other_source.scheme
         return false unless File.fnmatch(@host_pattern, other_source.host_pattern)
         return false unless @port_pattern.nil? || @port_pattern == "*" || @port_pattern = other_source.port_pattern

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -8,6 +8,7 @@ require_relative "scheme_source_expression"
 module SecureHeaders
   class ContentSecurityPolicy
     def parse_source_expression(s)
+      puts ("parsing: #{s}")
       SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::PathReportingEndpoint.try_parse(s) ||

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -16,12 +16,3 @@ module SecureHeaders
     end
   end
 end
-
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
-# s.to_s
-# nSecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
-# puts "\n\ns: #{s.to_s}\n\n"
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "host_source_expression"
+require_relative "quoted_source_expression"
+require_relative "scheme_source_expression"
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    def parse_source_expression(s)
+      SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
+        SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
+        SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
+    end
+  end
+end
+
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
+# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
+# s.to_s
+# nSecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
+# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
+# puts "\n\ns: #{s.to_s}\n\n"
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "host_source_expression"
+require_relative "path_reporting_endpoint"
 require_relative "quoted_source_expression"
 require_relative "scheme_source_expression"
 
@@ -9,6 +10,7 @@ module SecureHeaders
     def parse_source_expression(s)
       SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
+        SecureHeaders::ContentSecurityPolicy::PathReportingEndpoint.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -11,6 +11,7 @@ module SecureHeaders
       SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::PathReportingEndpoint.try_parse(s) ||
+        # TODO: bare directive like `style-src` are parsed as hosts. They should be handled separately.
         SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -8,7 +8,6 @@ require_relative "scheme_source_expression"
 module SecureHeaders
   class ContentSecurityPolicy
     def parse_source_expression(s)
-      puts ("parsing: #{s}")
       SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::PathReportingEndpoint.try_parse(s) ||

--- a/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/parse_source_expression.rb
@@ -11,7 +11,7 @@ module SecureHeaders
       SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::PathReportingEndpoint.try_parse(s) ||
-        # TODO: bare directive like `style-src` are parsed as hosts. They should be handled separately.
+        # TODO: bare directives like `style-src` are parsed as hosts. They should be handled separately.
         SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
+++ b/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
@@ -19,7 +19,7 @@ module SecureHeaders
       end
 
       def self.try_parse(s)
-        endpoint_match = s.match(/\A(?<endpoint>\/.*)\z/)
+        endpoint_match = s.match(/\A(?<endpoint>\/[^;,\n]*)\z/)
         return nil if endpoint_match.nil?
         endpoint = endpoint_match[:endpoint]
         new(

--- a/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
+++ b/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
@@ -10,7 +10,7 @@ module SecureHeaders
     class PathReportingEndpoint < SourceExpression
       attr_reader :endpoint
 
-      def initialize(scheme:)
+      def initialize(endpoint:)
         @endpoint = endpoint
       end
 
@@ -21,10 +21,11 @@ module SecureHeaders
       def self.try_parse(s)
         endpoint_match = s.match(/\A(?<endpoint>\/.*)\z/)
         return nil if endpoint_match.nil?
-        endpoint = endpoint_match[:scheme]
+        endpoint = endpoint_match[:endpoint]
         new(
           endpoint: endpoint
         )
       end
+    end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
+++ b/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require_relative "source_expression"
+
 module SecureHeaders
   class ContentSecurityPolicy
     # TODO: A reporting endpoint is not a source expression, but we don't make
-    # that distinction in the rest of our code yet.
-    class PathReportingEndpoint
+    # that distinction in the rest of our code yet. We need to make the rest of
+    # the code parse closer to spec, and then we can remove this subclass.
+    class PathReportingEndpoint < SourceExpression
       attr_reader :endpoint
 
       def initialize(scheme:)
@@ -15,14 +18,6 @@ module SecureHeaders
         @endpoint
       end
 
-      def has_wildcard?
-        false
-      end
-
-      def matches_same_or_superset?(other_source)
-        false
-      end
-
       def self.try_parse(s)
         endpoint_match = s.match(/\A(?<endpoint>\/.*)\z/)
         return nil if endpoint_match.nil?
@@ -31,12 +26,5 @@ module SecureHeaders
           endpoint: endpoint
         )
       end
-
-      def self.parse(s)
-        maybe_parsed = self.try_parse(s)
-        throw "Could not parse path reporting endpoint" if maybe_parsed.nil?
-        maybe_parsed
-      end
-    end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
+++ b/lib/secure_headers/headers/content_security_policy/path_reporting_endpoint.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    # TODO: A reporting endpoint is not a source expression, but we don't make
+    # that distinction in the rest of our code yet.
+    class PathReportingEndpoint
+      attr_reader :endpoint
+
+      def initialize(scheme:)
+        @endpoint = endpoint
+      end
+
+      def to_s
+        @endpoint
+      end
+
+      def has_wildcard?
+        false
+      end
+
+      def matches_same_or_superset?(other_source)
+        false
+      end
+
+      def self.try_parse(s)
+        endpoint_match = s.match(/\A(?<endpoint>\/.*)\z/)
+        return nil if endpoint_match.nil?
+        endpoint = endpoint_match[:scheme]
+        new(
+          endpoint: endpoint
+        )
+      end
+
+      def self.parse(s)
+        maybe_parsed = self.try_parse(s)
+        throw "Could not parse path reporting endpoint" if maybe_parsed.nil?
+        maybe_parsed
+      end
+    end
+  end
+end

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -26,12 +26,6 @@ module SecureHeaders
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Rather than validating against the spec, we are flexible here for now.
         value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\-\+_=]+')\z/)
-        puts "-----"
-        puts "-----"
-        puts s
-        puts value_match
-        puts "-----"
-        puts "-----"
         return nil if value_match.nil?
         value = value_match[:value]
         new(

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -25,7 +25,7 @@ module SecureHeaders
       def self.try_parse(s)
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Rather than validating against the spec, we are flexible here for now.
-        value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\-\+_=]+')\z/)
+        value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\+\/\-_=]+')\z/)
         return nil if value_match.nil?
         value = value_match[:value]
         new(

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -10,7 +10,7 @@ module SecureHeaders
         @value = value
       end
 
-      def to_str
+      def to_s
         "#{value}"
       end
 
@@ -46,10 +46,10 @@ end
 
 kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'self'")
 kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'-self'")
-kse.to_str
+kse.to_s
 
 kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='")
 kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'nonce-abcdefg'")
-kse.to_str
+kse.to_s
 kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'wasm-unsafe-eval'")
-kse.to_str
+kse.to_s

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -35,13 +35,3 @@ module SecureHeaders
     end
   end
 end
-
-kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'self'")
-kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'-self'")
-kse.to_s
-
-kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='")
-kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'nonce-abcdefg'")
-kse.to_s
-kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'wasm-unsafe-eval'")
-kse.to_s

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -24,17 +24,21 @@ module SecureHeaders
         @value == other_source.value
       end
 
-      def self.parse(s)
-        puts "--------"
-        
+      def self.try_parse(s)
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Rather than validating against the spec, we are flexible here for now.
         value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\-\+_=]+')\z/)
+        return nil if value_match.nil?
         value = value_match[:value]
-        
         new(
           value: value
         )
+      end
+
+      def self.parse(s)
+        maybe_parsed = self.maybe_parse(s)
+        throw "Could not parse quoted source expression" if maybe_parsed.nil?
+        maybe_parsed
       end
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "source_expression"
+
 module SecureHeaders
   class ContentSecurityPolicy
     # Keyword, nonce, or hash source
-    class QuotedSourceExpression
+    class QuotedSourceExpression < SourceExpression
       attr_reader :value
 
       def initialize(value:)
@@ -12,10 +14,6 @@ module SecureHeaders
 
       def to_s
         "#{value}"
-      end
-
-      def has_wildcard?
-        false
       end
 
       # For now, we only return true for exact matches.
@@ -28,17 +26,17 @@ module SecureHeaders
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Rather than validating against the spec, we are flexible here for now.
         value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\-\+_=]+')\z/)
+        puts "-----"
+        puts "-----"
+        puts s
+        puts value_match
+        puts "-----"
+        puts "-----"
         return nil if value_match.nil?
         value = value_match[:value]
         new(
           value: value
         )
-      end
-
-      def self.parse(s)
-        maybe_parsed = self.try_parse(s)
-        throw "Could not parse quoted source expression" if maybe_parsed.nil?
-        maybe_parsed
       end
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    # Keyword, nonce, or hash source
+    class QuotedSourceExpression
+      attr_reader :value
+
+      def initialize(value:)
+        @value = value
+      end
+
+      def to_str
+        "#{value}"
+      end
+
+      def has_wildcard?
+        false
+      end
+
+      # For now, we only return true for exact matches.
+      def matches_same_or_superset?(other_source)
+        return false unless other_source.is_a?(QuotedSourceExpression)
+        @value == other_source.value
+      end
+
+      def self.parse(s)
+        puts "--------"
+        
+        # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
+        # Rather than validating against the spec, we are flexible here for now.
+        value_match = s.match(/\A(?<value>'[[[:alpha:]][[:digit:]]\-\+_=]+')\z/)
+        value = value_match[:value]
+        
+        new(
+          value: value
+        )
+      end
+    end
+  end
+end
+
+kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'self'")
+kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'-self'")
+kse.to_str
+
+kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'sha256-B2yPHKaXnvFWtRChIbabYmUBFZdVfKKXHbWtWidDVF8='")
+kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'nonce-abcdefg'")
+kse.to_str
+kse = SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse("'wasm-unsafe-eval'")
+kse.to_str

--- a/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/quoted_source_expression.rb
@@ -36,7 +36,7 @@ module SecureHeaders
       end
 
       def self.parse(s)
-        maybe_parsed = self.maybe_parse(s)
+        maybe_parsed = self.try_parse(s)
         throw "Could not parse quoted source expression" if maybe_parsed.nil?
         maybe_parsed
       end

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    class HostSourceExpression
+      attr_reader :scheme
+
+      def initialize(scheme)
+        @scheme = scheme
+      end
+
+      def to_str
+        @scheme + ":"
+      end
+
+      def has_wildcard?
+        false
+      end
+
+      def matches_same_or_superset?(other_source)
+        return false unless other_source.is_a?(SchemeSourceExpression)
+        @scheme == other_source.scheme
+      end
+
+      def self.try_parse(s)
+        scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):)?\z/)
+        return nil if scheme_match.nil?
+        scheme = scheme_match[:scheme]
+        new(
+          scheme: scheme
+        )
+      end
+
+      def self.parse(s)
+        maybe_parsed = self.maybe_parse(s)
+        throw "Could not parse scheme source expression" if maybe_parsed.nil?
+        maybe_parsed
+      end
+    end
+  end
+end

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -5,7 +5,7 @@ module SecureHeaders
     class SchemeSourceExpression
       attr_reader :scheme
 
-      def initialize(scheme)
+      def initialize(scheme:)
         @scheme = scheme
       end
 

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -2,7 +2,7 @@
 
 module SecureHeaders
   class ContentSecurityPolicy
-    class HostSourceExpression
+    class SchemeSourceExpression
       attr_reader :scheme
 
       def initialize(scheme)
@@ -32,7 +32,7 @@ module SecureHeaders
       end
 
       def self.parse(s)
-        maybe_parsed = self.maybe_parse(s)
+        maybe_parsed = self.try_parse(s)
         throw "Could not parse scheme source expression" if maybe_parsed.nil?
         maybe_parsed
       end

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -8,12 +8,10 @@ module SecureHeaders
       attr_reader :scheme
 
       def initialize(scheme:)
-        puts "SCHEMESOURCE EXPRRR scheme #{scheme}"
         @scheme = scheme
       end
 
       def to_s
-        puts "SCHEMESOURCE EXPRRR schem2@@@e #{@scheme}"
         @scheme + ":"
       end
 
@@ -24,7 +22,6 @@ module SecureHeaders
 
       def self.try_parse(s)
         scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):)\z/)
-        puts("scheme_match #{scheme_match}\n\ns: #{s}")
         return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         new(

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "source_expression"
+
 module SecureHeaders
   class ContentSecurityPolicy
-    class SchemeSourceExpression
+    class SchemeSourceExpression < SourceExpression
       attr_reader :scheme
 
       def initialize(scheme:)
@@ -11,10 +13,6 @@ module SecureHeaders
 
       def to_s
         @scheme + ":"
-      end
-
-      def has_wildcard?
-        false
       end
 
       def matches_same_or_superset?(other_source)
@@ -29,12 +27,6 @@ module SecureHeaders
         new(
           scheme: scheme
         )
-      end
-
-      def self.parse(s)
-        maybe_parsed = self.try_parse(s)
-        throw "Could not parse scheme source expression" if maybe_parsed.nil?
-        maybe_parsed
       end
     end
   end

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -8,10 +8,12 @@ module SecureHeaders
       attr_reader :scheme
 
       def initialize(scheme:)
+        puts "SCHEMESOURCE EXPRRR scheme #{scheme}"
         @scheme = scheme
       end
 
       def to_s
+        puts "SCHEMESOURCE EXPRRR schem2@@@e #{@scheme}"
         @scheme + ":"
       end
 
@@ -21,7 +23,8 @@ module SecureHeaders
       end
 
       def self.try_parse(s)
-        scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):)?\z/)
+        scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):)\z/)
+        puts("scheme_match #{scheme_match}\n\ns: #{s}")
         return nil if scheme_match.nil?
         scheme = scheme_match[:scheme]
         new(

--- a/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/scheme_source_expression.rb
@@ -9,7 +9,7 @@ module SecureHeaders
         @scheme = scheme
       end
 
-      def to_str
+      def to_s
         @scheme + ":"
       end
 

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 require_relative "host_source_expression"
-require_relative "host_source_expression"
+require_relative "quoted_source_expression"
+require_relative "scheme_source_expression"
 
 module SecureHeaders
   class ContentSecurityPolicy
     def parse_source_expression(s)
-      return SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s) if s.start_with?("'")
-      
+      SecureHeaders::ContentSecurityPolicy::HostSourceExpression.try_parse(s) ||
+        SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
+        SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse(s)
     end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -17,8 +17,8 @@ end
 # SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
 # SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
 # s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
-# s.to_str
+# s.to_s
 # nSecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
 # s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
-# puts "\n\ns: #{s.to_str}\n\n"
+# puts "\n\ns: #{s.to_s}\n\n"
 # SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -7,9 +7,9 @@ require_relative "scheme_source_expression"
 module SecureHeaders
   class ContentSecurityPolicy
     def parse_source_expression(s)
-      SecureHeaders::ContentSecurityPolicy::HostSourceExpression.try_parse(s) ||
+      SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
         SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
-        SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.parse(s)
+        SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
     end
   end
 end

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "host_source_expression"
+require_relative "host_source_expression"
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    def parse_source_expression(s)
+      return SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s) if s.start_with?("'")
+      
+    end
+  end
+end
+
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
+# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
+# s.to_str
+# nSecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
+# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
+# puts "\n\ns: #{s.to_str}\n\n"
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -1,24 +1,33 @@
 # frozen_string_literal: true
 
-require_relative "host_source_expression"
-require_relative "quoted_source_expression"
-require_relative "scheme_source_expression"
-
 module SecureHeaders
   class ContentSecurityPolicy
-    def parse_source_expression(s)
-      SecureHeaders::ContentSecurityPolicy::QuotedSourceExpression.try_parse(s) ||
-        SecureHeaders::ContentSecurityPolicy::SchemeSourceExpression.try_parse(s) ||
-        SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse(s)
+    class SourceExpression
+      def initialize(scheme:)
+        throw "Cannot instantiate directly"
+      end
+
+      def to_s
+        throw "Unimplemented"
+      end
+
+      def has_wildcard?
+        false
+      end
+
+      def matches_same_or_superset?(other_source)
+        false
+      end
+
+      def self.try_parse(s)
+        throw "Unimplemented"
+      end
+
+      def self.parse(s)
+        maybe_parsed = self.try_parse(s)
+        throw "Could not parse scheme source expression" if maybe_parsed.nil?
+        maybe_parsed
+      end
     end
   end
 end
-
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
-# s.to_s
-# nSecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
-# s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
-# puts "\n\ns: #{s.to_s}\n\n"
-# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/content_security_policy/source_expression.rb
+++ b/lib/secure_headers/headers/content_security_policy/source_expression.rb
@@ -25,7 +25,7 @@ module SecureHeaders
 
       def self.parse(s)
         maybe_parsed = self.try_parse(s)
-        throw "Could not parse scheme source expression" if maybe_parsed.nil?
+        throw "Could not parse source expression" if maybe_parsed.nil?
         maybe_parsed
       end
     end

--- a/lib/secure_headers/headers/csp_host_source_expression.rb
+++ b/lib/secure_headers/headers/csp_host_source_expression.rb
@@ -23,6 +23,13 @@ module SecureHeaders
         @host_pattern.start_with("*") || @port_pattern == "*"
       end
 
+      # Example: *.example.com matches *.subdomain.example.com
+      def matches_superset?(other_source)
+        # https://w3c.github.io/webappsec-csp/#match-url-to-source-expression
+        return false unless self.@scheme != nil && self.@scheme !== other_source.@scheme
+        return false unless File.fnmatch(self.@host, other_source.@host)
+      end
+
       def self.parse(s)
         puts "--------"
         
@@ -49,7 +56,7 @@ module SecureHeaders
 
         # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
         # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
-        path_match = after_port.match(/\A(?<path>\/[^;:]*)?\z/)
+        path_match = after_port.match(/\A(?<path>(\/[^;:]*)?)\z/)
         path = path_match[:path]
         puts "path: #{path}"
 
@@ -71,4 +78,4 @@ end
 # SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("url-aldkjf")
 # s = SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("http://localhost:3434/fsd")
 # puts "\n\ns: #{s.to_str}\n\n"
-# SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")
+SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/csp_host_source_expression.rb
+++ b/lib/secure_headers/headers/csp_host_source_expression.rb
@@ -85,7 +85,7 @@ end
 # SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("aa.df://r")
 # s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("*")
 # s.to_str
-SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjf")
 # s = SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("http://localhost:3434/fsd")
 # puts "\n\ns: #{s.to_str}\n\n"
 # SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/csp_host_source_expression.rb
+++ b/lib/secure_headers/headers/csp_host_source_expression.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module SecureHeaders
+  class ContentSecurityPolicy
+    class HostSourceExpression
+      def initialize(scheme: nil, host_pattern:, port_pattern: nil, path: nil)
+        @scheme = scheme
+        @host_pattern = host_pattern
+        @port_pattern = port_pattern
+        @path = path
+      end
+
+      def to_str
+        output = @host_pattern
+        output = @scheme + "://" + output if @scheme
+        output += ":" + @port_pattern if @port_pattern
+        output += @path if @path
+        output
+      end
+
+      # The host or scheme can contain a wildcard
+      def has_wildcard?
+        @host_pattern.start_with("*") || @port_pattern == "*"
+      end
+
+      def self.parse(s)
+        puts "--------"
+        
+        # https://www.rfc-editor.org/rfc/rfc3986#section-3.1
+        scheme_match = s.match(/\A((?<scheme>[[:alpha:]][[[:alpha:]][[:digit:]]\+\-\.]*):\/\/)?(?<rest>.*)\z/)
+        scheme = scheme_match[:scheme]
+        after_scheme = scheme_match[:rest]
+        puts "scheme: #{scheme}"
+        puts "after_scheme: #{after_scheme}"
+
+        # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
+        host_match = after_scheme.match(/\A(?<host_pattern>\*|(\*\.)?[[[:alpha:]][[:digit:]]\-][[[:alpha:]][[:digit:]]\-\.]*)(?<rest>.*)\z/)
+        host_pattern = host_match[:host_pattern]
+        after_host = host_match[:rest]
+        puts "host_pattern: #{host_pattern}"
+        puts "after_host: #{after_host}"
+
+        # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
+        port_match = after_host.match(/\A(:(?<port>[[:digit:]]+|\*))?(?<rest>.*)\z/)
+        port_pattern = port_match[:port]
+        after_port = port_match[:rest]
+        puts "port_pattern: #{port_pattern}"
+        puts "after_port: #{after_port}"
+
+        # https://w3c.github.io/webappsec-csp/#grammardef-scheme-part
+        # Loosely based on https://www.rfc-editor.org/rfc/rfc3986#section-3.3
+        path_match = after_port.match(/\A(?<path>\/[^;:]*)?\z/)
+        path = path_match[:path]
+        puts "path: #{path}"
+
+        new(
+          scheme: scheme,
+          host_pattern: host_pattern,
+          port_pattern: port_pattern,
+          path: path
+        )
+      end
+    end
+  end
+end
+
+# SecureHeaders::ContentSecurityPolicy::HostSourceExpression.parse("url-aldkjfl://*")
+# SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("aa.df://r")
+# s = SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("*")
+# s.to_str
+# SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("url-aldkjf")
+# s = SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("http://localhost:3434/fsd")
+# puts "\n\ns: #{s.to_str}\n\n"
+# SecureHeaders::ContentSecurityPolicy::SourceExpression.parse("https://w3c.github.io/webappsec-csp/#grammardef-scheme-part")

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -166,7 +166,8 @@ module SecureHeaders
 
     FETCH_SOURCES = ALL_DIRECTIVES - NON_FETCH_SOURCES - NON_SOURCE_LIST_SOURCES
 
-    STAR_REGEXP = Regexp.new(Regexp.escape(STAR))
+    DOMAIN_WILDCARD_REGEX = /(?<=\A|[^:])\*/
+    PORT_WILDCARD_REGEX = /:\*/
     HTTP_SCHEME_REGEX = %r{\Ahttps?://}
 
     WILDCARD_SOURCES = [

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -117,14 +117,14 @@ module SecureHeaders
         expect(csp.value).to eq("default-src example.org")
       end
 
-      it "does not deduplicate non-matching schema source expressions" do
-        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://example.example.org))
-        expect(csp.value).to eq("default-src *.example.org wss://example.example.org")
+      it "deduplicates host source expression with wildcards" do
+        csp = ContentSecurityPolicy.new(default_src: %w(http://*.example.org http://a.example.org http://*.example.org:*))
+        expect(csp.value).to eq("default-src *.example.org:*")
       end
 
-      it "does not deduplicate non-matching schema source expressions 2" do
-        csp = ContentSecurityPolicy.new(default_src: %w(http://*.example.org))
-        expect(csp.value).to eq("default-src *.example.org")
+      it "does not deduplicate non-matching host source expressions" do
+        csp = ContentSecurityPolicy.new(default_src: %w(*.example.org wss://example.example.org))
+        expect(csp.value).to eq("default-src *.example.org wss://example.example.org")
       end
 
       it "creates maximally strict sandbox policy when passed no sandbox token values" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -122,6 +122,11 @@ module SecureHeaders
         expect(csp.value).to eq("default-src *.example.org wss://example.example.org")
       end
 
+      it "does not deduplicate non-matching schema source expressions 2" do
+        csp = ContentSecurityPolicy.new(default_src: %w(http://*.example.org))
+        expect(csp.value).to eq("default-src *.example.org")
+      end
+
       it "creates maximally strict sandbox policy when passed no sandbox token values" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org), sandbox: [])
         expect(csp.value).to eq("default-src example.org; sandbox")

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -29,13 +29,13 @@ module SecureHeaders
       end
 
       it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "google.com;script-src *;.;" which will raise an error in future versions. It has been replaced with a blank space.))
+        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "https://google.com;script-src https://*;.;" which will raise an error in future versions. It has been replaced with a blank space.))
         expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;.;)).value).to eq("frame-ancestors google.com script-src * .")
       end
 
       it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a \n in "\\nfoo.com\\nhacked" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: ["\nfoo.com\nhacked"]).value).to eq("frame-ancestors  foo.com hacked")
+        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a \n in "\\nfoo.com\\n'hacked'" which will raise an error in future versions. It has been replaced with a blank space.))
+        expect(ContentSecurityPolicy.new(frame_ancestors: ["\nfoo.com\n'hacked'"]).value).to eq("frame-ancestors  foo.com hacked")
       end
 
       it "discards 'none' values if any other source expressions are present" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -56,6 +56,16 @@ module SecureHeaders
         expect(csp.value).to eq("default-src *.example.org")
       end
 
+      it "minifies overlapping port wildcards" do
+        csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org:* example.org:443 https://example.org:80))
+        expect(csp.value).to eq("default-src example.org example.org:*")
+      end
+
+      it "allows for port wildcards" do
+        csp = ContentSecurityPolicy.new(connect_src: %w(ws://localhost:*))
+        expect(csp.value).to eq("connect-src ws://localhost:*")
+      end
+
       it "removes http/s schemes from hosts" do
         csp = ContentSecurityPolicy.new(default_src: %w(https://example.org))
         expect(csp.value).to eq("default-src example.org")
@@ -102,7 +112,8 @@ module SecureHeaders
       end
 
       it "deduplicates any source expressions" do
-        csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org example.org))
+        src = %w(example.org example.org http://example.org https://example.org)
+        csp = ContentSecurityPolicy.new(default_src: src)
         expect(csp.value).to eq("default-src example.org")
       end
 

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -58,7 +58,7 @@ module SecureHeaders
 
       it "minifies overlapping port wildcards" do
         csp = ContentSecurityPolicy.new(default_src: %w(example.org example.org:* example.org:443 https://example.org:80))
-        expect(csp.value).to eq("default-src example.org example.org:*")
+        expect(csp.value).to eq("default-src example.org:*")
       end
 
       it "allows for port wildcards" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -35,7 +35,7 @@ module SecureHeaders
 
       it "deprecates and escapes semicolons in directive source lists" do
         expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a \n in "\\nfoo.com\\n'hacked'" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: ["\nfoo.com\n'hacked'"]).value).to eq("frame-ancestors  foo.com hacked")
+        expect(ContentSecurityPolicy.new(frame_ancestors: ["\nfoo.com\n'hacked'"]).value).to eq("frame-ancestors foo.com 'hacked'")
       end
 
       it "discards 'none' values if any other source expressions are present" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -29,8 +29,8 @@ module SecureHeaders
       end
 
       it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "https://google.com;script-src https://*;example.com;" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;example.com;)).value).to eq("frame-ancestors google.com script-src * example.com")
+        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "https://google.com;script-src https://localhost;example.com;" which will raise an error in future versions. It has been replaced with a blank space.))
+        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://localhost;example.com;)).value).to eq("frame-ancestors google.com script-src localhost example.com")
       end
 
       it "deprecates and escapes semicolons in directive source lists" do

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -29,8 +29,8 @@ module SecureHeaders
       end
 
       it "deprecates and escapes semicolons in directive source lists" do
-        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "https://google.com;script-src https://*;.;" which will raise an error in future versions. It has been replaced with a blank space.))
-        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;.;)).value).to eq("frame-ancestors google.com script-src * .")
+        expect(Kernel).to receive(:warn).with(%(frame_ancestors contains a ; in "https://google.com;script-src https://*;example.com;" which will raise an error in future versions. It has been replaced with a blank space.))
+        expect(ContentSecurityPolicy.new(frame_ancestors: %w(https://google.com;script-src https://*;example.com;)).value).to eq("frame-ancestors google.com script-src * example.com")
       end
 
       it "deprecates and escapes semicolons in directive source lists" do


### PR DESCRIPTION
Recently, we've had a spate of fixes for parsing directives and source expressions, stemming from the fact that the code doesn't understand the format of valid expressions, and makes local assumptions about what they look like — in particular, assuming a resemblance to URLs during deduplication, when handling a lot of possible values that are not URLs.

https://github.com/github/secure_headers/pull/490
https://github.com/github/secure_headers/pull/478

This PR is an attempt to 'bite the bullet" and parse source expressions so we can semantically deduplicate matching URLs. In the future, we could use this to add more validation.

## All PRs:

* [x] Has tests
* [ ] ~Documentation updated~ (N/A)

## Adding a new header
