### PR TITLE
CI changes: run on push, drop Ruby 2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build + Test
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.6', '2.7', '3.0', '3.1' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 2.5 has been failing on CI since https://github.com/github/secure_headers/pull/499 and is no longer supported.