### PR TITLE
deprecate block-all-mixed-content

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ SecureHeaders::Configuration.default do |config|
     # directive values: these values will directly translate into source directives
     default_src: %w('none'),
     base_uri: %w('self'),
-    block_all_mixed_content: true, # see https://www.w3.org/TR/mixed-content/
     child_src: %w('self'), # if child-src isn't supported, the value for frame-src will be set.
     connect_src: %w(wss:),
     font_src: %w('self' data:),
@@ -91,6 +90,9 @@ SecureHeaders::Configuration.default do |config|
   })
 end
 ```
+
+### Deprecated Configuration Values
+* `block_all_mixed_content` - this value is deprecated in favor of `upgrade_insecure_requests`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content for more information.
 
 ## Default values
 

--- a/lib/secure_headers/headers/content_security_policy_config.rb
+++ b/lib/secure_headers/headers/content_security_policy_config.rb
@@ -16,7 +16,6 @@ module SecureHeaders
 
     def initialize(hash)
       @base_uri = nil
-      @block_all_mixed_content = nil
       @child_src = nil
       @connect_src = nil
       @default_src = nil

--- a/lib/secure_headers/headers/policy_management.rb
+++ b/lib/secure_headers/headers/policy_management.rb
@@ -71,7 +71,6 @@ module SecureHeaders
 
     # All the directives currently under consideration for CSP level 3.
     # https://w3c.github.io/webappsec/specs/CSP2/
-    BLOCK_ALL_MIXED_CONTENT = :block_all_mixed_content
     MANIFEST_SRC = :manifest_src
     NAVIGATE_TO = :navigate_to
     PREFETCH_SRC = :prefetch_src
@@ -85,7 +84,6 @@ module SecureHeaders
 
     DIRECTIVES_3_0 = [
       DIRECTIVES_2_0,
-      BLOCK_ALL_MIXED_CONTENT,
       MANIFEST_SRC,
       NAVIGATE_TO,
       PREFETCH_SRC,
@@ -118,7 +116,6 @@ module SecureHeaders
 
     DIRECTIVE_VALUE_TYPES = {
       BASE_URI                  => :source_list,
-      BLOCK_ALL_MIXED_CONTENT   => :boolean,
       CHILD_SRC                 => :source_list,
       CONNECT_SRC               => :source_list,
       DEFAULT_SRC               => :source_list,
@@ -241,7 +238,7 @@ module SecureHeaders
       #
       # raises an error if the original config is OPT_OUT
       #
-      # 1. for non-source-list values (report_only, block_all_mixed_content, upgrade_insecure_requests),
+      # 1. for non-source-list values (report_only, upgrade_insecure_requests),
       # additions will overwrite the original value.
       # 2. if a value in additions does not exist in the original config, the
       # default-src value is included to match original behavior.

--- a/spec/lib/secure_headers/headers/content_security_policy_spec.rb
+++ b/spec/lib/secure_headers/headers/content_security_policy_spec.rb
@@ -92,13 +92,13 @@ module SecureHeaders
       end
 
       it "does add a boolean directive if the value is true" do
-        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], block_all_mixed_content: true, upgrade_insecure_requests: true)
-        expect(csp.value).to eq("default-src example.org; block-all-mixed-content; upgrade-insecure-requests")
+        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], upgrade_insecure_requests: true)
+        expect(csp.value).to eq("default-src example.org; upgrade-insecure-requests")
       end
 
       it "does not add a boolean directive if the value is false" do
-        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], block_all_mixed_content: true, upgrade_insecure_requests: false)
-        expect(csp.value).to eq("default-src example.org; block-all-mixed-content")
+        csp = ContentSecurityPolicy.new(default_src: ["https://example.org"], upgrade_insecure_requests: false)
+        expect(csp.value).to eq("default-src example.org")
       end
 
       it "handles wildcard subdomain with wildcard port" do

--- a/spec/lib/secure_headers/headers/policy_management_spec.rb
+++ b/spec/lib/secure_headers/headers/policy_management_spec.rb
@@ -30,7 +30,6 @@ module SecureHeaders
           default_src: %w(https: 'self'),
 
           base_uri: %w('self'),
-          block_all_mixed_content: true, # see [http://www.w3.org/TR/mixed-content/](http://www.w3.org/TR/mixed-content/)
           connect_src: %w(wss:),
           child_src: %w('self' *.twimg.com itunes.apple.com),
           font_src: %w('self' data:),
@@ -89,12 +88,6 @@ module SecureHeaders
       it "requires :preserve_schemes to be a truthy value" do
         expect do
           ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(preserve_schemes: "steve")))
-        end.to raise_error(ContentSecurityPolicyConfigError)
-      end
-
-      it "requires :block_all_mixed_content to be a boolean value" do
-        expect do
-          ContentSecurityPolicy.validate_config!(ContentSecurityPolicyConfig.new(default_opts.merge(block_all_mixed_content: "steve")))
         end.to raise_error(ContentSecurityPolicyConfigError)
       end
 
@@ -244,18 +237,18 @@ module SecureHeaders
         expect(csp.name).to eq(ContentSecurityPolicyReportOnlyConfig::HEADER_NAME)
       end
 
-      it "overrides the :block_all_mixed_content flag" do
+      it "overrides the :upgrade_insecure_requests flag" do
         Configuration.default do |config|
           config.csp = {
             default_src: %w(https:),
             script_src: %w('self'),
-            block_all_mixed_content: false
+            upgrade_insecure_requests: false
           }
         end
         default_policy = Configuration.dup
-        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, block_all_mixed_content: true)
+        combined_config = ContentSecurityPolicy.combine_policies(default_policy.csp.to_h, upgrade_insecure_requests: true)
         csp = ContentSecurityPolicy.new(combined_config)
-        expect(csp.value).to eq("default-src https:; block-all-mixed-content; script-src 'self'")
+        expect(csp.value).to eq("default-src https:; script-src 'self'; upgrade-insecure-requests")
       end
 
       it "raises an error if appending to a OPT_OUT policy" do


### PR DESCRIPTION
* update tests and readme to reflect this change
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content:x

## All PRs:

* [x] Has tests
* [x] Documentation updated